### PR TITLE
Add Customized Code Font for making the site look more beautiful

### DIFF
--- a/assets/css/syntax.scss
+++ b/assets/css/syntax.scss
@@ -108,6 +108,10 @@ figure.highlight,
 }
 
 .highlight pre {
+  /* Test other fonts in this website here before writing them down in font-family here */
+  /* https://www.w3schools.com/howto/howto_google_fonts.asp */
+  font-family: 'Fira Code'; 
+  font-feature-settings: 'kern', 'liga', 'dlig', 'hlig', 'cswh';
   margin-bottom: 0;
   font-size: .85rem;
   line-height: 1.4rem;


### PR DESCRIPTION
This pull request adds an extra feature in which code blocks have a separate code font called "Fira Code" which has many beautiful ligatures. Below is the screenshot of how it would look on Github Pages. 
![image](https://user-images.githubusercontent.com/9385832/71246205-75eafe00-22d3-11ea-82e2-d18f7a90915c.png)
See the beautiful ligatures it brings into the code, which makes reading code more easier. Also, having a personal code font for code bloggers can be a big plus for this beautiful theme.