### PR TITLE
Allow special characters in categories and tags

### DIFF
--- a/_includes/panel.html
+++ b/_includes/panel.html
@@ -61,8 +61,8 @@
 
       {% for trend in trends %}
         {% assign count = count | plus: 1 %}
-        {% assign tag = trend | split: ":" | last  %}
-        <a class="post-tag" href="{{ site.baseurl }}/tags/{{ tag | downcase }}/">{{ tag | replace: '-', ' ' }}</a>
+        {% assign tag = trend | split: ":" | last %}
+        <a class="post-tag" href="{{ site.baseurl }}/tags/{{ tag | downcase | url_encode }}/">{{ tag | replace: '-', ' ' }}</a>
         {% if count >= MAX %}
           {% break %}
         {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,7 +20,7 @@ layout: default
           </span>
           {% if page.categories.size > 0 %}on{% endif %}
           {% for category in page.categories %}
-            <a href='{{ site.baseurl }}/categories/{{ category | replace: ' ', '-' | downcase }}/'>{{ category }}</a>
+            <a href='{{ site.baseurl }}/categories/{{ category | replace: ' ', '-' | downcase | url_encode }}/'>{{ category }}</a>
             {%- unless forloop.last -%}, {%- endunless -%}
           {% endfor %}
         </div>
@@ -62,7 +62,7 @@ layout: default
         {% if page.tags.size > 0 %}
         <div class="mb-4">
           {% for tag in page.tags %}
-          <a href="{{ site.baseurl }}/tags/{{ tag | replace: ' ', '-' | downcase }}/"
+          <a href="{{ site.baseurl }}/tags/{{ tag | replace: ' ', '-' | downcase | url_encode }}/"
             class="post-tag no-text-decoration" >
             {{- tag -}}
           </a>

--- a/tabs/categories.md
+++ b/tabs/categories.md
@@ -33,7 +33,7 @@ title: Categories
       {% else %}
         <i class="far fa-folder fa-fw"></i>
       {% endif %}
-        <a href="{{ site.baseurl }}/categories/{{ category_name | replace: ' ', '-' | downcase }}/">{{ category_name }}</a>
+        <a href="{{ site.baseurl }}/categories/{{ category_name | replace: ' ', '-' | downcase | url_encode }}/">{{ category_name }}</a>
         <!-- content count -->
         {% assign top_posts_size = site.categories[category_name] | size %}
         <span class="text-muted small font-weight-light pl-2">
@@ -63,7 +63,7 @@ title: Categories
       <ul class="list-group">
         {% for sub_category in sub_categories %}
         <li class="list-group-item">
-          <i class="far fa-folder fa-fw"></i>&nbsp;<a href="{{ site.baseurl }}/categories/{{ sub_category | replace: ' ', '-' | downcase }}/">{{ sub_category }}</a>
+          <i class="far fa-folder fa-fw"></i>&nbsp;<a href="{{ site.baseurl }}/categories/{{ sub_category | replace: ' ', '-' | downcase | url_encode }}/">{{ sub_category }}</a>
           {% assign posts_size = site.categories[sub_category] | size %}
           <span class="text-muted small font-weight-light pl-2">{{ posts_size }}
             post{% if posts_size > 1 %}s{% endif %}

--- a/tabs/tags.md
+++ b/tabs/tags.md
@@ -20,7 +20,7 @@ title: Tags
 
 {% for t in sorted_tags %}
   <div>
-    <a class="tag" href="{{ site.baseurl }}/tags/{{ t | downcase | replace: ' ', '-' }}/">{{ t }}<span class="text-muted">{{ site.tags[t].size }}</span></a>
+    <a class="tag" href="{{ site.baseurl }}/tags/{{ t | replace: ' ', '-' | downcase | url_encode }}/">{{ t }}<span class="text-muted">{{ site.tags[t].size }}</span></a>
   </div>
 {% endfor %}
 


### PR DESCRIPTION
I found that links did not work if I set 'C#' as either category, sub-category or tag. The changes in this pull request fixed the problem with links within category tab, tags tab, in top and bottom section of posts, and with tags in right-side panel.