### PR TITLE
[Feature] Allow toggling of dark scheme + Display elements based on color scheme

### DIFF
--- a/assets/css/_dark/dark-main.scss
+++ b/assets/css/_dark/dark-main.scss
@@ -6,55 +6,65 @@
 * MIT Licensed
 */
 
+@mixin darkScheme() {
+  /* framework */
+  --main-wrapper-bg: rgb(27, 27, 30);
+  --topbar-wrapper-bg: rgb(39, 40, 43);
+  --search-wrapper-bg: rgb(34, 34, 39);
+  --search-icon: rgb(100, 102, 105);
+  --input-focus-border: rgb(112, 114, 115);
+  --footer-bg: rgb(31, 30, 30);
+  --footer-border: rgb(44, 45, 45);
+  --mask-bg: rgb(68, 69, 70);
+
+  /* sidebar */
+  --nav-cursor: rgb(183, 182, 182);
+  --sidebar-bg: radial-gradient(circle, #242424 0%, #1d1f27 100%);
+
+  /* common color */
+  --text-color: rgb(175, 176, 177);
+  --text-muted-color: rgb(107, 116, 124);
+  --link-color: #3db5c2;
+  --link-underline-color: #3db5c2;
+  --main-border: rgb(63, 65, 68);
+  --button-bg: rgb(39, 40, 33);
+  --blockquote-border: rgb(66, 66, 66);
+  --blockquote-text: rgb(117, 117, 117);
+
+  --card-bg: rgb(39, 40, 33);
+  --card-header-bg: rgb(51, 50, 50);
+  --relate-post-title: rgb(164, 175, 181);
+
+  /* Home page */
+  --btn-active-bg: #1c345e;
+  --btn-active-border-color: #8ab4f8;
+
+  /* posts */
+  --toc-highlight: rgb(116, 178, 243);
+  --tag-bg: rgb(41, 40, 40);
+  --tag-hover: rgb(43, 56, 62);
+  --tb-odd-bg: rgba(52, 53, 42, 0.52); /* odd rows of the posts' table */
+  --tb-even-bg: rgb(31, 31, 34); /* even rows of the posts' table */
+
+  /* tags */
+  --tag-border: rgb(59, 79, 88);
+  --tag-shadow: rgb(32, 33, 33);
+
+  /* categories */
+  --categories-hover-bg: rgb(73, 75, 76);
+
+  /* archives */
+  --timeline-node-bg: rgb(150, 152, 156);
+}
+
 @media (prefers-color-scheme: dark) {
-  html {
-    /* framework */
-    --main-wrapper-bg: rgb(27, 27, 30);
-    --topbar-wrapper-bg: rgb(39, 40, 43);
-    --search-wrapper-bg: rgb(34, 34, 39);
-    --search-icon: rgb(100, 102, 105);
-    --input-focus-border: rgb(112, 114, 115);
-    --footer-bg: rgb(31, 30, 30);
-    --footer-border: rgb(44, 45, 45);
-    --mask-bg: rgb(68, 69, 70);
+  body:not(.color-scheme-light) {
+    @include darkScheme();
+  }
+}
 
-    /* sidebar */
-    --nav-cursor: rgb(183, 182, 182);
-    --sidebar-bg: radial-gradient(circle, #242424 0%, #1d1f27 100%);
-
-    /* common color */
-    --text-color: rgb(175, 176, 177);
-    --text-muted-color: rgb(107, 116, 124);
-    --link-color: rgb(138, 180, 248);
-    --link-underline-color: rgb(99, 131, 182);
-    --main-border: rgb(63, 65, 68);
-    --button-bg: rgb(39, 40, 33);
-    --blockquote-border: rgb(66, 66, 66);
-    --blockquote-text: rgb(117, 117, 117);
-
-    --card-bg: rgb(39, 40, 33);
-    --card-header-bg: rgb(51, 50, 50);
-    --relate-post-title: rgb(164, 175, 181);
-
-    /* Home page */
-    --btn-active-bg: #1c345e;
-    --btn-active-border-color: #8ab4f8;
-
-    /* posts */
-    --toc-highlight: rgb(116, 178, 243);
-    --tag-bg: rgb(41, 40, 40);
-    --tag-hover: rgb(43, 56, 62);
-    --tb-odd-bg: rgba(52, 53, 42, 0.52); /* odd rows of the posts' table */
-    --tb-even-bg: rgb(31, 31, 34); /* even rows of the posts' table */
-
-    /* tags */
-    --tag-border: rgb(59, 79, 88);
-    --tag-shadow: rgb(32, 33, 33);
-
-    /* categories */
-    --categories-hover-bg: rgb(73, 75, 76);
-
-    /* archives */
-    --timeline-node-bg: rgb(150, 152, 156);
+@media not (prefers-color-scheme: dark) {
+  body.color-scheme-dark {
+    @include darkScheme();
   }
 }

--- a/assets/css/_dark/dark-main.scss
+++ b/assets/css/_dark/dark-main.scss
@@ -57,14 +57,59 @@
   --timeline-node-bg: rgb(150, 152, 156);
 }
 
-@media (prefers-color-scheme: dark) {
-  body:not(.color-scheme-light) {
-    @include darkScheme();
+
+/* Light scheme prefered (= dark scheme not prefered)
+ * -> dark scheme triggered with <body class="color-scheme-dark">
+ */
+body.color-scheme-dark{
+  /* Dark scheme */
+  @include darkScheme();
+  // Hide element in dark color scheme
+  // (visible in light scheme)
+  .color-scheme-dark-hidden {
+    display: none;
+  }
+  .color-scheme-light-hidden {
+    display: initial;
+  }
+}
+body:not(.color-scheme-dark) {
+  /* Light scheme */
+  // Hide element in dark color scheme
+  // (visible in light scheme)
+  .color-scheme-light-hidden {
+    display: none;
+  }
+  .color-scheme-dark-hidden {
+    display: initial;
   }
 }
 
-@media not (prefers-color-scheme: dark) {
-  body.color-scheme-dark {
+@media (prefers-color-scheme: dark) {
+  /* Dark scheme prefered
+   * -> light scheme triggered with <body class="color-scheme-light">
+   */
+  body:not(.color-scheme-light) {
+    /* Dark scheme */
     @include darkScheme();
+    // Hide element in dark color scheme
+    // (visible in light scheme)
+    .color-scheme-dark-hidden {
+      display: none;
+    }
+    .color-scheme-light-hidden {
+      display: initial;
+    }
+  }
+  body.color-scheme-light {
+    /* Light scheme */
+    // Hide element in dark color scheme
+    // (visible in light scheme)
+    .color-scheme-light-hidden {
+      display: none;
+    }
+    .color-scheme-dark-hidden {
+      display: initial;
+    }
   }
 }

--- a/assets/css/_dark/dark-syntax.scss
+++ b/assets/css/_dark/dark-syntax.scss
@@ -6,77 +6,76 @@
 * MIT Licensed
 */
 
-@media (prefers-color-scheme: dark) {
-  html {
-    /* syntax highlight colors from https://raw.githubusercontent.com/jwarby/pygments-css/master/monokai.css */
-    --highlight-pre-bg: #272822;
-    --highlight-hll-bg: #272822;
-    --highlight-c: #75715e; /* Comment */
-    --highlight-err: #960050; /* Error */
-    --highlight-err-bg: #1e0010; /* Error background */
-    --highlight-k: #66d9ef; /* Keyword */
-    --highlight-l: #ae81ff; /* Literal */
-    --highlight-n: #f8f8f2; /* Name */
-    --highlight-o: #f92672; /* Operator */
-    --highlight-p: #f8f8f2; /* Punctuation */
-    --highlight-cm: #75715e; /* Comment.Multiline */
-    --highlight-cp: #75715e; /* Comment.Preproc */
-    --highlight-c1: #75715e; /* Comment.Single */
-    --highlight-cs: #75715e; /* Comment.Special */
-    --highlight-kc: #66d9ef; /* Keyword.Constant */
-    --highlight-kd: #66d9ef; /* Keyword.Declaration */
-    --highlight-kn: #f92672; /* Keyword.Namespace */
-    --highlight-kp: #66d9ef; /* Keyword.Pseudo */
-    --highlight-kr: #66d9ef; /* Keyword.Reserved */
-    --highlight-kt: #66d9ef; /* Keyword.Type */
-    --highlight-ld: #e6db74; /* Literal.Date */
-    --highlight-m: #ae81ff; /* Literal.Number */
-    --highlight-s: #e6db74; /* Literal.String */
-    --highlight-na: #a6e22e; /* Name.Attribute */
-    --highlight-nb: #f8f8f2; /* Name.Builtin */
-    --highlight-nc: #a6e22e; /* Name.Class */
-    --highlight-no: #66d9ef; /* Name.Constant */
-    --highlight-nd: #a6e22e; /* Name.Decorator */
-    --highlight-ni: #f8f8f2; /* Name.Entity */
-    --highlight-ne: #a6e22e; /* Name.Exception */
-    --highlight-nf: #a6e22e; /* Name.Function */
-    --highlight-nl: #f8f8f2; /* Name.Label */
-    --highlight-nn: #f8f8f2; /* Name.Namespace */
-    --highlight-nx: #a6e22e; /* Name.Other */
-    --highlight-py: #f8f8f2; /* Name.Property */
-    --highlight-nt: #f92672; /* Name.Tag */
-    --highlight-nv: #f8f8f2; /* Name.Variable */
-    --highlight-ow: #f92672; /* Operator.Word */
-    --highlight-w: #f8f8f2; /* Text.Whitespace */
-    --highlight-mf: #ae81ff; /* Literal.Number.Float */
-    --highlight-mh: #ae81ff; /* Literal.Number.Hex */
-    --highlight-mi: #ae81ff; /* Literal.Number.Integer */
-    --highlight-mo: #ae81ff; /* Literal.Number.Oct */
-    --highlight-sb: #e6db74; /* Literal.String.Backtick */
-    --highlight-sc: #e6db74; /* Literal.String.Char */
-    --highlight-sd: #e6db74; /* Literal.String.Doc */
-    --highlight-s2: #e6db74; /* Literal.String.Double */
-    --highlight-se: #ae81ff; /* Literal.String.Escape */
-    --highlight-sh: #e6db74; /* Literal.String.Heredoc */
-    --highlight-si: #e6db74; /* Literal.String.Interpol */
-    --highlight-sx: #e6db74; /* Literal.String.Other */
-    --highlight-sr: #e6db74; /* Literal.String.Regex */
-    --highlight-s1: #e6db74; /* Literal.String.Single */
-    --highlight-ss: #e6db74; /* Literal.String.Symbol */
-    --highlight-bp: #f8f8f2; /* Name.Builtin.Pseudo */
-    --highlight-vc: #f8f8f2; /* Name.Variable.Class */
-    --highlight-vg: #f8f8f2; /* Name.Variable.Global */
-    --highlight-vi: #f8f8f2; /* Name.Variable.Instance */
-    --highlight-il: #ae81ff; /* Literal.Number.Integer.Long */
+@mixin darkSchemeHighlight() {
 
-    // --highlight-gh: none; /* Generic Heading & Diff Header */
-    --highlight-gu: #75715e; /* Generic.Subheading & Diff Unified/Comment? */
-    --highlight-gd: #f92672; /* Generic.Deleted & Diff Deleted */
+  /* syntax highlight colors from https://raw.githubusercontent.com/jwarby/pygments-css/master/monokai.css */
+  --highlight-pre-bg: #272822;
+  --highlight-hll-bg: #272822;
+  --highlight-c: #75715e; /* Comment */
+  --highlight-err: #960050; /* Error */
+  --highlight-err-bg: #1e0010; /* Error background */
+  --highlight-k: #66d9ef; /* Keyword */
+  --highlight-l: #ae81ff; /* Literal */
+  --highlight-n: #f8f8f2; /* Name */
+  --highlight-o: #f92672; /* Operator */
+  --highlight-p: #f8f8f2; /* Punctuation */
+  --highlight-cm: #75715e; /* Comment.Multiline */
+  --highlight-cp: #75715e; /* Comment.Preproc */
+  --highlight-c1: #75715e; /* Comment.Single */
+  --highlight-cs: #75715e; /* Comment.Special */
+  --highlight-kc: #66d9ef; /* Keyword.Constant */
+  --highlight-kd: #66d9ef; /* Keyword.Declaration */
+  --highlight-kn: #f92672; /* Keyword.Namespace */
+  --highlight-kp: #66d9ef; /* Keyword.Pseudo */
+  --highlight-kr: #66d9ef; /* Keyword.Reserved */
+  --highlight-kt: #66d9ef; /* Keyword.Type */
+  --highlight-ld: #e6db74; /* Literal.Date */
+  --highlight-m: #ae81ff; /* Literal.Number */
+  --highlight-s: #e6db74; /* Literal.String */
+  --highlight-na: #a6e22e; /* Name.Attribute */
+  --highlight-nb: #f8f8f2; /* Name.Builtin */
+  --highlight-nc: #a6e22e; /* Name.Class */
+  --highlight-no: #66d9ef; /* Name.Constant */
+  --highlight-nd: #a6e22e; /* Name.Decorator */
+  --highlight-ni: #f8f8f2; /* Name.Entity */
+  --highlight-ne: #a6e22e; /* Name.Exception */
+  --highlight-nf: #a6e22e; /* Name.Function */
+  --highlight-nl: #f8f8f2; /* Name.Label */
+  --highlight-nn: #f8f8f2; /* Name.Namespace */
+  --highlight-nx: #a6e22e; /* Name.Other */
+  --highlight-py: #f8f8f2; /* Name.Property */
+  --highlight-nt: #f92672; /* Name.Tag */
+  --highlight-nv: #f8f8f2; /* Name.Variable */
+  --highlight-ow: #f92672; /* Operator.Word */
+  --highlight-w: #f8f8f2; /* Text.Whitespace */
+  --highlight-mf: #ae81ff; /* Literal.Number.Float */
+  --highlight-mh: #ae81ff; /* Literal.Number.Hex */
+  --highlight-mi: #ae81ff; /* Literal.Number.Integer */
+  --highlight-mo: #ae81ff; /* Literal.Number.Oct */
+  --highlight-sb: #e6db74; /* Literal.String.Backtick */
+  --highlight-sc: #e6db74; /* Literal.String.Char */
+  --highlight-sd: #e6db74; /* Literal.String.Doc */
+  --highlight-s2: #e6db74; /* Literal.String.Double */
+  --highlight-se: #ae81ff; /* Literal.String.Escape */
+  --highlight-sh: #e6db74; /* Literal.String.Heredoc */
+  --highlight-si: #e6db74; /* Literal.String.Interpol */
+  --highlight-sx: #e6db74; /* Literal.String.Other */
+  --highlight-sr: #e6db74; /* Literal.String.Regex */
+  --highlight-s1: #e6db74; /* Literal.String.Single */
+  --highlight-ss: #e6db74; /* Literal.String.Symbol */
+  --highlight-bp: #f8f8f2; /* Name.Builtin.Pseudo */
+  --highlight-vc: #f8f8f2; /* Name.Variable.Class */
+  --highlight-vg: #f8f8f2; /* Name.Variable.Global */
+  --highlight-vi: #f8f8f2; /* Name.Variable.Instance */
+  --highlight-il: #ae81ff; /* Literal.Number.Integer.Long */
 
-    /* My styles */
-    --highlight-lineno: #6c6c6d;
-    --highlight-lineno-border: #3c4042;
-  }
+  // --highlight-gh: none; /* Generic Heading & Diff Header */
+  --highlight-gu: #75715e; /* Generic.Subheading & Diff Unified/Comment? */
+  --highlight-gd: #f92672; /* Generic.Deleted & Diff Deleted */
+
+  /* My styles */
+  --highlight-lineno: #6c6c6d;
+  --highlight-lineno-border: #3c4042;
 
   pre {
     color: #818c96; /* override Bootstrap */
@@ -85,5 +84,16 @@
   kbd {
     background-color: black;
   }
+}
 
+@media (prefers-color-scheme: dark) {
+  body:not(.color-scheme-light) {
+    @include darkSchemeHighlight();
+  }
+}
+
+@media not (prefers-color-scheme: dark) {
+  body.color-scheme-dark {
+    @include darkSchemeHighlight();
+  }
 }


### PR DESCRIPTION
Hi @cotes2020 , I'm about to implement this feature in my fork and figured it might be useful for others as well.

**This PR allows you to switch between dark and light scheme** with a body class. The implementation detail is left on developers, but this is an example of how to implement such switch:

```
<button
  class="color-scheme-dark-hidden"
  onclick="
    $('body')
      .removeClass('color-scheme-light')
      .addClass('color-scheme-dark')
  ">Dark scheme</button>
<button
  class="color-scheme-light-hidden"
  onclick="
    $('body')
      .removeClass('color-scheme-dark')
      .addClass('color-scheme-light')
  ">Light scheme</button>
```