### PR TITLE
Run and build inside a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN bundle install
 
 CMD ["/bin/sh"]
 
-ENTRYPOINT ["./tools/run.sh", "-h"]
+ENTRYPOINT ["./tools/run.sh", ""]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,3 @@ RUN gem install jekyll -v3.8
 RUN bundle install
 
 CMD ["/bin/sh"]
-
-ENTRYPOINT ["./tools/run.sh", ""]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:2.4-slim
+
+WORKDIR /app
+
+COPY Gemfile .
+
+RUN apt-get -y update && apt-get -y install python3 python3-pip make gcc  g++ git
+
+RUN pip3 install ruamel.yaml
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+RUN gem install jekyll -v3.8
+
+RUN bundle install
+
+CMD ["/bin/sh"]
+
+ENTRYPOINT ["./tools/run.sh", "-h"]

--- a/README.md
+++ b/README.md
@@ -214,13 +214,13 @@ and enjoy!
 
 #### Option 3: Build with Docker
 
-If you don't want to install the Python and Ruby dependencies, you can run and build inside a Docker container.
+If you don't want to install the Python and Ruby dependencies, you can run and build the website inside a Docker container.
 
 1. To build the Docker image, run `Docker build -t chirpy-build .`
 
 2. To run locally, just type `Docker run --rm -v ${PWD}:/app chirpy-build tools/run.sh`
 
-3. To build locally, type `Docker run --rm -v ${PWD}:/app chirpy-build tools/build.sh`
+3. To build locally, type `Docker run --rm -v ${PWD}:/app chirpy-build tools/build.sh`. The resulting files are in the _site folder
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,16 @@ The generated static files will be placed in the root of `/path/to/local/project
 
 and enjoy!
 
+#### Option 3: Build with Docker
+
+If you don't want to install the Python and Ruby dependencies, you can run and build inside a Docker container.
+
+1. To build the Docker image, run `Docker build -t chirpy-build .`
+
+2. To run locally, just type `Docker run --rm -v ${PWD}:/app chirpy-build tools/run.sh`
+
+3. To build locally, type `Docker run --rm -v ${PWD}:/app chirpy-build tools/build.sh`
+
 ### Documentation
 
 For more details and the better reading experience, please check out the [tutorial in demo site](https://chirpy.cotes.info/categories/tutorial/). In the meanwhile, a copy of the tutorial is also available on the [Wiki](https://github.com/cotes2020/jekyll-theme-chirpy/wiki).

--- a/_config.yml
+++ b/_config.yml
@@ -183,6 +183,7 @@ exclude:
   - Gemfile
   - tools
   - docs
+  - Dockerfile
 
 sitemap_exclude:  # Sitemap will exclude the following items.
   fuzzy:


### PR DESCRIPTION
To avoid installing all the dependencies (python + ruby + deps) in order to build the website files, I added a Dockerfile.

1. To build the Docker image, run `Docker build -t chirpy-build .`

2. To run locally, just type `Docker run --rm -v ${PWD}:/app chirpy-build tools/run.sh`

3. To build locally, type `Docker run --rm -v ${PWD}:/app chirpy-build tools/build.sh`. The resulting files are in the _site folder