### PR TITLE
Fix to search result overflow

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -384,6 +384,7 @@ $sidebar-display: "sidebar-display";
 }
 
 #search-results {
+  word-break: break-word;
   padding-bottom: 6rem;
   a {
     @extend %link-color;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -384,7 +384,6 @@ $sidebar-display: "sidebar-display";
 }
 
 #search-results {
-  word-break: break-word;
   padding-bottom: 6rem;
   a {
     @extend %link-color;
@@ -1074,6 +1073,10 @@ table {
     .fa-times-circle {
       right: 5.2rem;
     }
+  }
+
+  #search-results>div {
+    max-width: 100% !important;
   }
 
   #search-input {


### PR DESCRIPTION
Adds word break on search result page preamble, this bug is caused when using code markdown early in a post a can be seen in the screenshot below.

![image](https://user-images.githubusercontent.com/9527854/80914616-de032380-8d4c-11ea-9c24-12e733c28b10.png)
