### PR TITLE
add example for mastodon contact

### DIFF
--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -21,6 +21,9 @@
 
 # Complete the url below to enable more contact options
 -
+  icon: 'fab fa-mastodon'   # icons powered by <https://fontawesome.com/>
+  url:  ''                  # Fill with your mastodon account page
+-
   icon: 'fab fa-linkedin'   # icons powered by <https://fontawesome.com/>
   url:  ''                  # Fill with your Linkedin homepage
 -


### PR DESCRIPTION
# Description

In `_data/contact.yml` arbritary contact links can be put and associated with an icon. font awesome ships a mastodon icon, so an example was added to the file. It will only show if the url-field is filled, as explained in the comment.

Fixes #81 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

... which unit tests? :)
- [ ] Any dependent changes have been merged and published in downstream modules