### PR TITLE
Remove disturbing paddings from <sup> tag

### DIFF
--- a/assets/css/_addon/main.scss
+++ b/assets/css/_addon/main.scss
@@ -661,10 +661,6 @@ kbd {
   margin: 0 .3rem;
 }
 
-sup {
-  @extend %anchor;
-}
-
 .footnotes ol {
   margin-top: .5rem;
   >li {
@@ -1099,10 +1095,6 @@ div.post-content .table-wrapper {
     -webkit-box-pack: center!important;
     -ms-flex-pack: center!important;
     justify-content: center!important;
-  }
-
-  sup {
-    padding-top: 3.4rem;
   }
 
   .footnotes ol > li {


### PR DESCRIPTION
**padding overlaps** when `<sup>` tags are aligned on same horizontal position, and it made some footnotes unclickable.

## Description

<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Bug fix

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [x] I have run `bash ./tools/build.sh && bash ./tools/test.sh` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browerser type & version:
- Operating system:
- Bundler version:
- Ruby version:
- Jekyll version:

### Checklist
<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] My code follows the [Google style guidelines](https://google.github.io/styleguide/)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules