### PR TITLE
Support for absolute URLs in tabs

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -31,12 +31,16 @@
   {% assign page_urls = page.url | split: "/" %}
 
   {% for item in site.data.tabs %}
-    {% assign ref = site.baseurl | append: "/" %}
+    {% if item.absolute %}
+      {% assign ref = item.url %}
+    {% else %}
+      {% assign ref = site.baseurl | append: "/" %}
 
-    {% if item.path %}
-      {% assign ref = ref | append: item.path | append: "/" %}
-      {% if item.url %}
-        {% assign ref = ref | append: item.url | append: "/" %}
+      {% if item.path %}
+        {% assign ref = ref | append: item.path | append: "/" %}
+        {% if item.url %}
+          {% assign ref = ref | append: item.url | append: "/" %}
+        {% endif %}
       {% endif %}
     {% endif %}
 
@@ -44,7 +48,8 @@
       {% if item.url == page_urls.last
         or item.name == page.tab_active
         or item.name == "Home" and page.layout == "home" %}active{% endif %}">
-      <a href="{{ ref }}" class="nav-link d-flex justify-content-center align-items-center w-100">
+      <a href="{{ ref }}" class="nav-link d-flex justify-content-center align-items-center w-100"
+        {% if item.absolute %} target="_blank" {%endif%} >
         <i class="fa-fw {{ item.icon }} ml-xl-3 mr-xl-3 unloaded"></i>
         <span>{{ item.name | upcase }}</span>
       </a>


### PR DESCRIPTION
## Description

Adds support for absolute/external URLs in tabs that will open in a new browser tab when a boolean is set.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

- [X] I have run `bash ./tools/build.sh && bash ./tools/test.sh` (at the root of the project) locally and passed
- [X] I have tested this feature in the browser

### Test Configuration

- Browerser type & version: Firefox Developer 82.0b2, Ungoogled Chromium 84.0.4147.135
- Operating system: Debian Testing
- Bundler version: 2.1.4
- Ruby version: 2.7.1p83
- Jekyll version: 4.1.1

### Checklist
- [X] My code follows the [Google style guidelines](https://google.github.io/styleguide/)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules