### PR TITLE
Changed post list rendering to use post.excerpt

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -58,7 +58,7 @@ layout: page
     </div>
     <div class="post-content">
       <p>
-        {% include no-linenos.html content=post.content %}
+        {% include no-linenos.html content=post.excerpt %}
         {{ content | markdownify | strip_html | truncate: 200 }}
       </p>
     </div>


### PR DESCRIPTION
## Changed post list rendering to use post.excerpt instead of post.content to respect jekyll's excerpt, so user would set whatever he wants as post excerpt.

only _layouts/home.html has changed.

## Type of change

- [ X] Bug fix (It changes how post lists are shown)

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ X] I have tested this feature in the browser

### Test Configuration

- Browerser type & version:
- Operating system: ArchLinux
- Bundler version: Bundler version 2.1.4
- Ruby version: ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-linux]
- Jekyll version: jekyll 4.1.1