### PR TITLE
Improve email javascript in sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -72,7 +72,7 @@
         https://twitter.com/{{ site.twitter.username }}
       {%- elsif entry.type == 'email' -%}
         {% assign email = site.social.email | split: '@' %}
-        javascript:window.open('mailto:' + ['{{ email[0] }}','{{ email[1] }}'].join('@'))
+        javascript:location.href = 'mailto:' + ['{{ email[0] }}','{{ email[1] }}'].join('@')
       {%- elsif entry.type == 'rss' -%}
         {{ "/feed.xml" | relative_url }}
       {%- else -%}


### PR DESCRIPTION
## Description
Clicking on the email 'social button' in the sidebar opens a blank page as wel as triggering my email client. This small change to the javascript triggering the email client doesn't create a blank page.

Remediates the issue described in [this stack overflow post]( https://stackoverflow.com/questions/21461589/javascript-mailto-using-window-open#32675594), using the recommended fix.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested
- [X] I have tested this feature in the browser

### Test Configuration

- Browerser type & version: Mozilla Firefox 81.0.1
- Operating system: Linux
- Ruby version: ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-linux]
- Jekyll version: v2.0
