### PR TITLE
Fix the dir name for hosting posts

### DIFF
--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -8,7 +8,7 @@ tags: [writing]
 
 ## Naming and Path
 
-Create a new file named `YYYY-MM-DD-TITLE.EXTENSION` and put it in the `_post/` of the root directory. Please note that the `EXTENSION` must be one of `md` and `markdown`.
+Create a new file named `YYYY-MM-DD-TITLE.EXTENSION` and put it in the `_posts/` of the root directory. Please note that the `EXTENSION` must be one of `md` and `markdown`.
 
 ## Front Matter
 


### PR DESCRIPTION
## Description

Fix instruction on where to host posts. (ie) the `/posts/` should hold all docs. not `/post`
## Type of change

- [x] Documentation update

## How has this been tested

Markdown change
- [x] I have tested this feature in the browser

### Test Configuration

- Browerser type & version:
- Operating system:
- Bundler version:
- Ruby version:
- Jekyll version:

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
