### PR TITLE
fixed typo in dark typography

### DIFF
--- a/assets/css/_colors/dark-typography.scss
+++ b/assets/css/_colors/dark-typography.scss
@@ -52,7 +52,7 @@
   --btn-paginator-border-color: var(--btn-border-color);
   --btn-paginator-shadow: var(--main-wrapper-bg);
   --pin-bg: rgb(34 35 37);
-  --pin-color: iherit;
+  --pin-color: inherit;
 
   /* Posts */
   --toc-highlight: rgb(116, 178, 243);


### PR DESCRIPTION
## Description"

"inherit" was spelled wrong in the dark typography scss.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

Not tested. Seems straightforward.
