### PR TITLE
added text-muted class to typography to override BS

### DIFF
--- a/assets/css/_colors/dark-typography.scss
+++ b/assets/css/_colors/dark-typography.scss
@@ -136,4 +136,8 @@
       rgb(26, 26, 30));
   }
 
+  .text-muted {
+    color: var(--text-muted-color) !important;
+  }
+
 } // dark-scheme

--- a/assets/css/_colors/light-typography.scss
+++ b/assets/css/_colors/light-typography.scss
@@ -77,4 +77,8 @@
   --footer-bg-color: #ffffff;
   --footnote-target-bg: lightcyan;
   --footer-link: #424242;
+
+  .text-muted {
+    color: var(--text-muted-color) !important;
+  }
 } // light-scheme


### PR DESCRIPTION
## Description

I noticed that bootstrap has `!important` on their text-muted class, which made it so that we couldn't control that color. So I added that class to the light/dark typography files, with an !important. And now we can adjust that color!

Let me know if you like this, but want it adjusted (like where I put the class in those files).

e.g. Fixes #(issue)

CSS update.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [x] I have tested this feature in the browser

