### PR TITLE
Add image alt attribute to the from the top of the post contents

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -45,7 +45,7 @@ layout: default
       <div class="post-content">
 
         {% if page.image %}
-          <img src="{{ page.image }}" class="preview-img" alt="Preview Image">
+          <img src="{{ page.image.src }}" class="preview-img" alt="{{ page.image.alt }}" />
         {% endif %}
 
         {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -44,7 +44,7 @@ layout: default
 
       <div class="post-content">
 
-        {% if page.image %}
+        {% if page.image.src %}
           <img src="{{ page.image.src }}" class="preview-img" alt="{{ page.image.alt }}" />
         {% endif %}
 

--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -84,22 +84,14 @@ Then you can use it like other markdown language: surround the graph code with `
 
 ### Preview image
 
-If you want to add an image to the top of the post contents, specify the url for the image by:
+If you want to add an image to the top of the post contents, specify the url and alt attribute for the image:
 
 ```yaml
 ---
 image:
-  src: /path/to/image-file
----
-```
-
-### Image alt attribute
-
-If you want to add the "alt attribute" to the image at the top of the post contents, specify it by:
-```yaml
----
-image:
+  src: /path/to/image/file
   alt: image alternative text
+---
 ```
 
 ### Image caption

--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -88,8 +88,18 @@ If you want to add an image to the top of the post contents, specify the url for
 
 ```yaml
 ---
-image: /path/to/image-file
+image:
+  src: /path/to/image-file
 ---
+```
+
+### Image alt attribute
+
+If you want to add the "alt attribute" to the image at the top of the post contents, specify it by:
+```yaml
+---
+image:
+  alt: image alternative text
 ```
 
 ### Image caption


### PR DESCRIPTION
## Description

<!-- 
Add image alt attribute to the image from the top of the post contents
-->

e.g. Fixes #(issue)

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How has this been tested

<!-- 
Tested on my own Jekyll instance running on MacOS Catalina
-->

- [x] I have run `bash ./tools/test.sh --build` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration
- Browser type & version: Safari v14.0.1
- Operating system: MacOS Catalina v10.15.7
- Bundler version: 2.2.7
- Ruby version: 2.5.5p15
- Jekyll version: 4.2.0

### Checklist
<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] My code follows the [Google style guidelines](https://google.github.io/styleguide/)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
