### PR TITLE
Adding image opening in a lightbox

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -66,6 +66,13 @@
     integrity="sha256-+N4/V/SbAFiW1MPBCXnfnP9QSN3+Keu+NlB+0ev/YKQ="
     crossorigin="anonymous">
 
+  <!-- Lightbox -->
+  <link rel="stylesheet" 
+    href="https://github.com/lokesh/lightbox2/blob/dev/dist/css/lightbox.min.css"
+    crossorigin="anonymous">
+  
+  <script src="https://github.com/lokesh/lightbox2/blob/master/dist/js/lightbox-plus-jquery.min.js"></script>
+
   {% include css-selector.html %}
 
   <!-- JavaScripts -->

--- a/_plugins/lightbox.rb
+++ b/_plugins/lightbox.rb
@@ -1,0 +1,59 @@
+# Jekyll Lightbox Plugin
+#
+# Bart Vandeweerdt | www.appfoundry.be
+#
+# Example usage: {% lightbox images/appfoundry.png --thumb="images/thumbs/appfoundry.png" --data="some data" --title="some title" --alt="some alt" --img-style="css styling" --class="yourclass"%}
+module Jekyll
+  class LightboxTag < Liquid::Tag
+
+    def initialize(tag_name, text, token)
+      super
+
+      # The path to our image
+      @path = Liquid::Template.parse(
+        # Regex: split on first whitespace character while allowing double quoting for surrounding spaces in a file path
+        text.split(/\s(?=(?:[^"]|"[^"]*")*$)/)[0].strip
+      ).render(@context)
+
+      # Defaults
+      @title = ''
+      @alt = ''
+      @img_style = ''
+      @class = ''
+      @data = ''
+      @thumb = @path
+
+      # Parse Options
+      if text =~ /--title="([^"]*)"/i
+        @title = text.match(/--title="([^"]*)"/i)[1]
+      end
+      if text =~ /--alt="([^"]*)"/i
+        @alt = text.match(/--alt="([^"]*)"/i)[1]
+      end
+      if text =~ /--img-style="([^"]*)"/i
+        @img_style = text.match(/--img-style="([^"]*)"/i)[1]
+      end
+      if text =~ /--class="([^"]*)"/i
+        @class = text.match(/--class="([^"]*)"/i)[1]
+      end
+      if text =~ /--data="([^"]*)"/i
+        @data = text.match(/--data="([^"]*)"/i)[1]
+      end
+      if text =~ /--thumb="([^"]*)"/i
+        @thumb = text.match(/--thumb="([^"]*)"/i)[1]
+      end
+
+
+    end
+
+    def render(context)
+      url = context.registers[:page]["url"]
+      relative = "../" * (url.split("/").length-1)
+      src = File.join(relative, @path == nil ? '' : @path);
+      thumbSrc = File.join(relative, @thumb == nil ? '' : @thumb);
+      %{<a href="#{src}" data-lightbox="#{@data}" data-title="#{@title}"><img src="#{thumbSrc}" alt="#{@alt || @title}" class="#{@class}" style="#{@img_style}"/></a>}
+    end
+  end
+end
+
+Liquid::Template.register_tag('lightbox', Jekyll::LightboxTag)

--- a/_posts/2019-08-08-text-and-typography.md
+++ b/_posts/2019-08-08-text-and-typography.md
@@ -101,6 +101,10 @@ Click the hook will locate the footnote[^footnote], and here is another footnote
 ![Desktop View](https://cdn.jsdelivr.net/gh/cotes2020/chirpy-images/posts/20190808/mockup.png)
 _Full screen width and center alignment_
 
+- Lightbox (with caption)
+{% lightbox https://cdn.jsdelivr.net/gh/cotes2020/chirpy-images/posts/20190808/mockup.png --thumb="https://cdn.jsdelivr.net/gh/cotes2020/chirpy-images/posts/20190808/mockup.png" --data="appfoundry_image_set" --title="Image opening in a lightbox" --alt="This is my image" --img-style="max-width:80%;" --class="yourclass" %}
+_Full screen width and center alignment_
+
 <br>
 
 - Specify width


### PR DESCRIPTION
## Description
Added the possibility to open image in a lightbox by applying [Jekyll Lightbox Plugin](https://github.com/appfoundry/jekyll-lightbox)

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

## How has this been tested

I have implemented this feature on my own website using your theme. So I did the same job here to share with everybody.

- [ ] I have run `bash ./tools/test.sh --build` (at the root of the project) locally and passed
- [X] I have tested this feature in the browser

### Test Configuration

- Browerser type & version: Firefox 86
- Operating system: Windows 10
- Bundler version: 
- Ruby version: 2.7
- Jekyll version: 4.2

### Checklist
<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [ ] My code follows the [Google style guidelines](https://google.github.io/styleguide/)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
