### PR TITLE
Prevent unwanted line break (Safari)

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,7 +13,7 @@ layout: default
 
       <h1 data-toc-skip>{{ page.title }}</h1>
 
-      <div class="post-meta text-muted d-flex flex-column">
+      <div class="post-meta text-muted text-nowrap d-flex flex-column">
         <!-- Published date and author -->
         <div>
           <span class="semi-bold">


### PR DESCRIPTION
## Description

On Safari the first `div` of the flex-box gets wrapped at the date's day.  
My suggestion would be to add `text-nowrap` to either the flex-box itself or just the first `div` (below "Published date and author").

Please feel free to make relevant changes or let me know if this is not a change you would want to make.

| Safari | Chrome |
| ----- | ----- |
|![Screen Shot 2021-10-03 at 20 09 12](https://user-images.githubusercontent.com/2669027/135751199-f93bd7eb-2381-428c-9be6-7c02cf2eba1a.png) | ![Screen Shot 2021-10-03 at 20 09 25](https://user-images.githubusercontent.com/2669027/135751203-bd0d5fa3-13e0-4939-bf51-c7b4fac42678.png)|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

- [ ] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed  
**This is not possible. Error:** `ERROR: This script is not allowed to run outside of GitHub Action.`
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Safari, Chrome (latest)
- Operating system: Mac OSX Big Sur
- Bundler version: 1.17.2
- Ruby version: 3.0.3
- Jekyll version: 4.2.1

