### PR TITLE
Accessibility Bug Fix: Tab focus doesn't reach Dark mode toggle button

### DIFF
--- a/_includes/mode-toggle.html
+++ b/_includes/mode-toggle.html
@@ -147,6 +147,6 @@
     {
       toggle.flipMode();
     }
-});
+  });
 
 </script>

--- a/_includes/mode-toggle.html
+++ b/_includes/mode-toggle.html
@@ -143,8 +143,7 @@
   });
 
   $("#mode-toggle-wrapper").keyup(function(e){
-    if(e.keyCode == 13)
-    {
+    if(e.keyCode == 13) {
       toggle.flipMode();
     }
   });

--- a/_includes/mode-toggle.html
+++ b/_includes/mode-toggle.html
@@ -142,4 +142,11 @@
 
   });
 
+  $("#mode-toggle-wrapper").keyup(function(e){
+    if(e.keyCode == 13)
+    {
+      toggle.flipMode();
+    }
+});
+
 </script>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -52,6 +52,15 @@
   </ul> <!-- ul.nav.flex-column -->
 
   <div class="sidebar-bottom mt-auto d-flex flex-wrap justify-content-center align-items-center">
+    {% unless site.theme_mode %}
+      {% if site.data.contact.size > 0 %}
+        <span class="icon-border order-2"></span>
+      {% endif %}
+
+      <span id="mode-toggle-wrapper" class="order-1" tabindex="0">
+        {% include mode-toggle.html %}
+      </span>
+    {% endunless %}
 
     {% for entry in site.data.contact %}
       {% capture url %}
@@ -78,17 +87,6 @@
       {% endif %}
 
     {% endfor %}
-
-    {% unless site.theme_mode %}
-      {% if site.data.contact.size > 0 %}
-        <span class="icon-border order-2"></span>
-      {% endif %}
-
-      <span id="mode-toggle-wrapper" class="order-1">
-        {% include mode-toggle.html %}
-      </span>
-    {% endunless %}
-
   </div> <!-- .sidebar-bottom -->
 
 </div><!-- #sidebar -->

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -52,6 +52,7 @@
   </ul> <!-- ul.nav.flex-column -->
 
   <div class="sidebar-bottom mt-auto d-flex flex-wrap justify-content-center align-items-center">
+    
     {% for entry in site.data.contact %}
       {% capture url %}
         {%- if entry.type == 'github' -%}
@@ -87,7 +88,7 @@
         {% include mode-toggle.html %}
       </span>
     {% endunless %}
-    
+
   </div> <!-- .sidebar-bottom -->
 
 </div><!-- #sidebar -->

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -52,16 +52,6 @@
   </ul> <!-- ul.nav.flex-column -->
 
   <div class="sidebar-bottom mt-auto d-flex flex-wrap justify-content-center align-items-center">
-    {% unless site.theme_mode %}
-      {% if site.data.contact.size > 0 %}
-        <span class="icon-border order-2"></span>
-      {% endif %}
-
-      <span id="mode-toggle-wrapper" class="order-1" tabindex="0">
-        {% include mode-toggle.html %}
-      </span>
-    {% endunless %}
-
     {% for entry in site.data.contact %}
       {% capture url %}
         {%- if entry.type == 'github' -%}
@@ -87,6 +77,17 @@
       {% endif %}
 
     {% endfor %}
+
+    {% unless site.theme_mode %}
+      {% if site.data.contact.size > 0 %}
+        <span class="icon-border order-2"></span>
+      {% endif %}
+
+      <span id="mode-toggle-wrapper" class="order-1" tabindex="0">
+        {% include mode-toggle.html %}
+      </span>
+    {% endunless %}
+    
   </div> <!-- .sidebar-bottom -->
 
 </div><!-- #sidebar -->


### PR DESCRIPTION
## Description
This is a fix for accessibility bug

- if you press tab then the focus doesn't reach dark mode toggle button
- After focus should reach the dark mode toggle button, pressing enter button should change the theme of website
![image](https://user-images.githubusercontent.com/26280748/144034218-79ee517e-cc5f-45e5-b908-06b1f2f9c8cb.png)

e.g. Fixes #(issue)
-->

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version:
- Operating system: Windows
- Ruby version: 2.7.4p191 
- Bundler version:  2.2.30
- Jekyll version: 4.2.1

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
