### PR TITLE
Bug Fix: Link in a heading is rendered as an anchor and becomes invisible.

### DIFF
--- a/_includes/refactor-content.html
+++ b/_includes/refactor-content.html
@@ -169,7 +169,7 @@
       {% endif %}
 
       {% assign id = snippet | split: '"' | first %}
-      {% capture anchor %}<a href="#{{ id }}"><i class="fas fa-hashtag"></i></a>{% endcapture %}
+      {% capture anchor %}<a href="#{{ id }}" class="anchor"><i class="fas fa-hashtag"></i></a>{% endcapture %}
 
       {% assign left = snippet | split: mark_end | first %}
       {% assign right = snippet | replace: left, '' %}

--- a/_sass/addon/module.scss
+++ b/_sass/addon/module.scss
@@ -18,13 +18,13 @@
 }
 
 %anchor {
-  > a {
+  .anchor {
     font-size: 1rem;
     margin-left: 0.5rem;
   }
 
   @media (hover: hover) {
-    > a {
+    .anchor {
       border-bottom: none !important;
       visibility: hidden;
       opacity: 0;
@@ -32,7 +32,7 @@
     }
 
     &:hover {
-      > a {
+      .anchor {
         visibility: visible;
         opacity: 1;
         transition: opacity 0.25s ease-in, visibility 0s ease-in 0s;
@@ -44,7 +44,7 @@
 %anchor-relative {
   @extend %anchor;
 
-  > a {
+  .anchor {
     position: relative;
     bottom: 1px;
   }


### PR DESCRIPTION
## Description

`<a>` tags in headings are set to apply the style of `%anchor` in `module.scss` and `common.scss`. Therefore, if I put a link in a heading, the link will have the same style as the anchor, which means that the font size becomes smaller and the link will not be displayed unless I hover the mouse over it.

For example, 
```
## Header with a [link](https://example.com)
```
in a markdown file is displayed like this.

![Animation](https://user-images.githubusercontent.com/14541102/147730375-fac6c3c5-5c4f-4ceb-a8f8-137dd32a84ba.gif)

My suggestion is to set an `anchor` class for the `<a>` tag of the anchor and apply style settings to the `anchor` class, not to the `a` tag.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

- [ ] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Google Chrome 96.0.4664.110
- Operating system: Windows 10 21H1 + WSL (18.04.1 LTS)
- Ruby version: 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux-gnu]
- Bundler version:  2.2.15
- Jekyll version: 4.2.1

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
