### PR TITLE
add css formatting for kbd element

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -106,8 +106,22 @@ blockquote {
   color: var(--blockquote-text-color);
 }
 
+/* Pretty Keyboard Keys
+usage: <kbd>⌘ Cmd</kbd>+<kbd>⇧ Shift</kbd>+<kbd>.</kbd> */
+
 kbd {
+  background-color: #ecede5;
+  border-radius: .1rem;
+  box-shadow: 0 0.1rem 0 0.05rem #686d59,0 0.1rem 0 #686d59,0 -0.1rem 0.2rem #fff inset;
+  color: #2d3329;
+  display: inline-block;
+  font-size: .75em;
+  font-family: var(--md-code-font-family),SFMono-Regular,Consolas,Menlo,monospace;
+  font-feature-settings: "kern";
   margin: 0 0.3rem;
+  padding: 0 .6666666667em;
+  vertical-align: text-top;
+  word-break: break-word;
 }
 
 footer {


### PR DESCRIPTION
## Description
No dependency required, this simply adds pretty formatting for the `kbd` element for when you need to add keyboard shortcuts to your posts.

usage: `<kbd>⌘ Cmd</kbd>+<kbd>⇧ Shift</kbd>+<kbd>.</kbd>`

I'm working on another pr to update the documentation page for text and typography that will include this change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

- [x] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed

```
bash ./tools/deploy.sh --dry-run
Configuration file: /Users/framirez/Documents/git/external/jekyll-theme-chirpy/_config.yml
 Theme Config file: /Users/framirez/Documents/git/external/jekyll-theme-chirpy/_config.yml
            Source: /Users/framirez/Documents/git/external/jekyll-theme-chirpy
       Destination: /Users/framirez/Documents/git/external/jekyll-theme-chirpy/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
                    done in 1.5 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
Running ["ScriptCheck", "LinkCheck", "ImageCheck", "HtmlCheck"] on ["_site"] on *.html...


Ran on 23 files!


HTML-Proofer finished successfully.
```
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: `Firefox 95.0.2 (64-bit)`
- Operating system: `macOS Big Sur 11.6.1`
- Ruby version: <!-- by running: `ruby -v` --> `ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin19]`
- Bundler version: <!-- by running: `bundle -v`--> `Bundler version 2.3.1`
- Jekyll version: <!-- by running: `bundle list | grep " jekyll "` --> `jekyll (4.2.1)`

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Screenshots

![Screen Shot 205](https://user-images.githubusercontent.com/22822565/147833965-ce8b7183-a622-44df-9d41-f6c18311cc84.png)
![Screen Shot 206](https://user-images.githubusercontent.com/22822565/147833966-8c01847b-208b-40fe-b51d-f768fd44250e.png)

