### PR TITLE
removing '' in data-proofer-ignore

### DIFF
--- a/_includes/refactor-content.html
+++ b/_includes/refactor-content.html
@@ -129,7 +129,7 @@
     {% endif %}
 
     <!-- Bypass the HTML-proofer test -->
-    {% assign _left = _left | append: ' data-proofer-ignore' %}
+    {% assign _left = _left | append: data-proofer-ignore %}
 
     {% assign _img_content = _img_content | append: IMG_TAG | append: _left | append: _right %}
 


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

e.g. Fixes #(issue)
-->

This is a bug fix when updating to 5.0.0 at least once per post, in my findings. See examples:

![image](https://user-images.githubusercontent.com/19912012/147989847-84c31e69-f1af-465d-b8ba-adc7cf6c5ac0.png)

![image](https://user-images.githubusercontent.com/19912012/147989868-c3d34bba-d74c-448d-b591-c9a21c541cd7.png)


Not sure if the fix is what was intended, but it removes the `data-proofer-ignore` bug. 


## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [X] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [X] I have tested this feature in the browser

### Test Configuration

- Browser type & version: `Brave (chromium) 1.33.106`
- Operating system: `macOS 11.6.3`
- Ruby version: `ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]`
- Bundler version: `Bundler version 2.2.26`
- Jekyll version:   `* jekyll (4.2.1)`

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
