### PR TITLE
Remove tab characters to pass json validation

### DIFF
--- a/assets/js/data/search.json
+++ b/assets/js/data/search.json
@@ -11,7 +11,7 @@ layout: compress
     "tags": "{{ post.tags | join: ', ' }}",
     "date": "{{ post.date }}",
     {% include no-linenos.html content=post.content %}
-    "snippet": "{{ content | strip_html | strip_newlines | remove_chars | escape | replace: '\', '\\\\' }}"
+    "snippet": "{{ content | strip_html | strip_newlines | remove_chars | escape | replace: '\', '\\\\' | replace: '	', ' ' }}"
   }{% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]


### PR DESCRIPTION
I have below problem

![image](https://user-images.githubusercontent.com/46277436/148041497-4c7d85fc-a223-43a4-9d95-c2bbf9976060.png)

After a while of researching, I realize we need to filter the tab characters to pass JSON validation of Simple Jekyll Search.

![image](https://user-images.githubusercontent.com/46277436/148042003-81d7a0d1-4f57-43da-9021-4bb3179656a9.png)
