### PR TITLE
Don't include Google Analytics scripts without analytics id

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -40,7 +40,7 @@
   <link rel="dns-prefetch" href="https://fonts.gstatic.com">
 
   <!-- GA -->
-  {% if jekyll.environment == 'production' %}
+  {% if jekyll.environment == 'production' and site.google_analytics.id != '' %}
     <link rel="preconnect" href="https://www.google-analytics.com" crossorigin="use-credentials">
     <link rel="dns-prefetch" href="https://www.google-analytics.com">
 

--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -61,7 +61,7 @@
   <script defer src="{{ '/app.js' | relative_url }}"></script>
 
   <!-- GA -->
-  {% if site.google_analytics.id %}
+  {% if site.google_analytics.id and site.google_analytics.id != '' %}
     {% include google-analytics.html %}
   {% endif %}
 


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

e.g. Fixes #(issue)
-->

I'm in the EU, so I have to turn off Google Analytics entirely to avoid legal issues. I noticed that the Google Analytics script was still being loaded even though I hadn't changed `google_analytics.id` from the empty string in `_config.yml`.

I'm not sure if the first part of the conditions is still needed, since I don't know the Liquid templating language.
I suspect it's necessary in case someone comments out that part of the configuration.

This is a bit of a "maybe you can use this" PR, since I'm maintaining my fork separately just for my page (because I customised a number of things outside the configuration files) and won't necessarily upgrade to the next version of Chirpy.

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
  (I'm on Windows, which is probably (part of) why this doesn't work for me. I did use bash.)
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Brave Version 1.34.80 Chromium: 97.0.4692.71 (Official Build) (64-bit)
- Operating system: Windows 10
- Ruby version: ruby 3.0.3p157 (2021-11-24 revision 3fb7d2cadc) [x64-mingw32]
- Bundler version: Bundler version 2.3.4
- Jekyll version: * jekyll (4.2.1)

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
  (It's a two-line adjustment that should be self-explanatory.)
- [x] I have made corresponding changes to the documentation
  (Or rather: There was nothing to update, since this doesn't change features.)
- [x] My changes generate no new warnings
