### PR TITLE
changed telegram share link api as per documentation

### DIFF
--- a/_data/share.yml
+++ b/_data/share.yml
@@ -13,7 +13,7 @@ platforms:
   -
     type: Telegram
     icon: "fab fa-telegram"
-    link: "https://telegram.me/share?text=TITLE&url=URL"
+    link: "https://t.me/share/url?url=URL&text=TITLE"
 
   # Uncomment below if you need to.
   # -


### PR DESCRIPTION
## Description

This is regarding https://github.com/cotes2020/jekyll-theme-chirpy/issues/488
This commit fixes the broken telegram sharing function by using the latest link as per official telegram documentation.
https://core.telegram.org/widgets/share#custom-buttons


## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser
- [x] I have tested this feature on iOS browsers (Safari/Chrome)
### Test Configuration

- Browser type & version: Safari, Chrome
- Operating system: iOS 15.1
- Ruby version: ruby 2.6.8p205 (2021-07-07 revision 67951) [universal.x86_64-darwin21]
- Gem version: 3.0.3.1
- Bundler version: Bundler version 2.3.5
- Jekyll version: * jekyll (4.2.1)

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
