### PR TITLE
Fix script location and URL encode share links

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -87,4 +87,7 @@
 
   <script src="{{ site.data.assets[origin].jquery.js }}"></script>
 
+  {% unless site.theme_mode %}
+    {% include mode-toggle.html %}
+  {% endunless %}
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -87,7 +87,4 @@
 
   <script src="{{ site.data.assets[origin].jquery.js }}"></script>
 
-  {% unless site.theme_mode %}
-    {% include mode-toggle.html %}
-  {% endunless %}
 </head>

--- a/_includes/post-sharing.html
+++ b/_includes/post-sharing.html
@@ -6,10 +6,11 @@
   <span class="share-label text-muted mr-1">{{ site.data.locales[lang].post.share }}</span>
   <span class="share-icons">
     {% capture title %}{{ page.title }} - {{ site.title }}{% endcapture %}
-    {% assign url = page.url | absolute_url %}
+    {% assign title = title | url_encode %}
+    {% assign url = page.url | absolute_url | url_encode %}
 
     {% for share in site.data.share.platforms %}
-      {% assign link = share.link | replace: 'TITLE', title | replace: 'URL', url | escape %}
+      {% assign link = share.link | replace: 'TITLE', title | replace: 'URL', url %}
         <a href="{{ link }}" data-toggle="tooltip" data-placement="top"
           title="{{ share.type }}" target="_blank" rel="noopener" aria-label="{{ share.type }}">
           <i class="fa-fw {{ share.icon }}"></i>

--- a/_includes/post-sharing.html
+++ b/_includes/post-sharing.html
@@ -6,11 +6,10 @@
   <span class="share-label text-muted mr-1">{{ site.data.locales[lang].post.share }}</span>
   <span class="share-icons">
     {% capture title %}{{ page.title }} - {{ site.title }}{% endcapture %}
-    {% assign title = title | url_encode %}
-    {% assign url = page.url | absolute_url | url_encode %}
+    {% assign url = page.url | absolute_url %}
 
     {% for share in site.data.share.platforms %}
-      {% assign link = share.link | replace: 'TITLE', title | replace: 'URL', url %}
+      {% assign link = share.link | replace: 'TITLE', title | replace: 'URL', url | escape %}
         <a href="{{ link }}" data-toggle="tooltip" data-placement="top"
           title="{{ share.type }}" target="_blank" rel="noopener" aria-label="{{ share.type }}">
           <i class="fa-fw {{ share.icon }}"></i>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,10 +19,6 @@ layout: compress
 
   {% include head.html %}
 
-  {% unless site.theme_mode %}
-    {% include mode-toggle.html %}
-  {% endunless %}
-
   <body data-spy="scroll" data-target="#toc" data-topbar-visible="true">
 
     {% include sidebar.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,6 +19,10 @@ layout: compress
 
   {% include head.html %}
 
+  {% unless site.theme_mode %}
+    {% include mode-toggle.html %}
+  {% endunless %}
+
   <body data-spy="scroll" data-target="#toc" data-topbar-visible="true">
 
     {% include sidebar.html %}


### PR DESCRIPTION
## Description

Theme toggle JS code was in between head and body tags (invalid placement), now moved to the head.

Share links now use `url_encode` instead of `escape` since the latter doesn't encode spaces and other special characters like '&' are encoded as HTML entities instead of % values (a post title containing an '&' will be cut short).

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Firefox 97.0.1
- Operating system: Windows 10
- Ruby version: 2.7.4p191
- Bundler version: 2.3.8
- Jekyll version: 4.2.1

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
