### PR TITLE
Use jsonify to generate valid JSON

### DIFF
--- a/assets/js/data/search.json
+++ b/assets/js/data/search.json
@@ -6,13 +6,13 @@ swcache: true
 [
   {% for post in site.posts %}
   {
-    "title": "{{ post.title | escape }}",
-    "url": "{{ post.url | relative_url }}",
-    "categories": "{{ post.categories | join: ', '}}",
-    "tags": "{{ post.tags | join: ', ' }}",
+    "title": {{ post.title | jsonify }},
+    "url": {{ post.url | relative_url | jsonify }},
+    "categories": {{ post.categories | join: ', ' | jsonify }},
+    "tags": {{ post.tags | join: ', ' | jsonify }},
     "date": "{{ post.date }}",
     {% include no-linenos.html content=post.content %}
-    "snippet": "{{ content | strip_html | strip_newlines | remove_chars | escape | replace: '\', '\\\\' }}"
+    "snippet": {{ content | strip_html | strip_newlines | jsonify }}
   }{% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]


### PR DESCRIPTION
## Description

Invalid JSON is generated when a post contains tab characters since the `remove_chars` filter plugin is missing ( https://github.com/christian-fei/Simple-Jekyll-Search/tree/master/example/_plugins ). Use `jsonify` instead.

Relates to https://github.com/cotes2020/jekyll-theme-chirpy/pull/475

Even if the text editor has been configured to use spaces instead of tabs, Rouge syntax highlighter will generate tabs in its tables.

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Firefox 97.0.1
- Operating system: Windows 10
- Ruby version: 2.7.4p191
- Bundler version: 2.3.8
- Jekyll version:  4.2.1

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
