### PR TITLE
feat: add pt-BR support to locales

### DIFF
--- a/_data/locales/pt-BR.yml
+++ b/_data/locales/pt-BR.yml
@@ -1,0 +1,78 @@
+# The layout text of site
+
+# ----- Commons label -----
+
+layout:
+  post: Post
+  category: Categoria
+  tag: Tag
+
+# The tabs of sidebar
+tabs:
+  # format: <filename_without_extension>: <value>
+  home: Home
+  categories: Categorias
+  tags: Tags
+  archives: Arquivos
+  about: Sobre
+
+# the text displayed in the search bar & search results
+search:
+  hint: Buscar
+  cancel: Cancelar
+  no_results: Oops! Nenhum resultado encontrado.
+
+panel:
+  lastmod: Atualizados recentemente
+  trending_tags: Trending Tags
+  toc: Conteúdo
+
+copyright:
+  # Shown at the bottom of the post
+  license:
+    template: Esta postagem está licenciada sob :LICENSE_NAME pelo autor.
+    name: CC BY 4.0
+    link: https://creativecommons.org/licenses/by/4.0/
+
+  # Displayed in the footer
+  brief: Alguns direitos reservados.
+  verbose: >-
+    Exceto onde indicado de outra forma, as postagens do blog neste site são licenciadas sob a 
+    Creative Commons Attribution 4.0 International (CC BY 4.0) License pelo autor.
+
+meta: Feito com :PLATFORM usando o tema :THEME.
+
+not_found:
+  statment: Desculpe, a página não foi encontrada.
+  hint_template: :HEAD_BAK para tentar encontrar novamente, ou procure na :ARCHIVES_PAGE.
+  head_back: Vá para a página inicial
+  archives_page: Página de arquivos
+
+# ----- Posts related labels -----
+
+post:
+  written_by: Por
+  posted: Postado em
+  updated: Atualizado
+  words: palavras
+  pageview_measure: visualizações
+  read_time:
+    unit: min
+    prompt: " de leitura"
+  relate_posts: Leia também
+  share: Compartilhar
+  button:
+    next: Próximo
+    previous: Anterior
+    copy_code:
+      succeed: Copiado!
+    share_link:
+      title: Copie o link
+      succeed: Link copiado com sucesso!
+  # pinned prompt of posts list on homepage
+  pin_prompt: Fixado
+
+# categories page
+categories:
+  category_measure: categorias
+  post_measure: posts


### PR DESCRIPTION
## Description

Add support for brazilian portuguese.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [ ] I have tested this feature in the browser
- [x] Not applicable

### Test Configuration

- Browser type & version:
- Operating system:
- Ruby version: <!-- by running: `ruby -v` -->
- Bundler version: <!-- by running: `bundle -v`-->
- Jekyll version: <!-- by running: `bundle list | grep " jekyll "` -->
- [x] Not applicable

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
