### PR TITLE
fix: force checkout of Pages branch

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -77,7 +77,7 @@ setup_gh() {
     _no_pages_branch=true
     git checkout -b "$PAGES_BRANCH"
   else
-    git checkout "$PAGES_BRANCH"
+    git checkout -f "$PAGES_BRANCH"
   fi
 }
 


### PR DESCRIPTION
When using the theme starter, which uses a git submodule, assets loaded from that submodule are "untracked" files in the pages branch working tree. The build can fail at this line due to Git, saying "the following untracked working tree files would be overwritten by checkout".

Adding `checkout -f` forces the checkout, overwriting all files. The other deploy steps then take over and rewrite the files as needed.

- Failing build with the old version: https://github.com/GriceTurrble/galenrice.com/runs/5790580358?check_suite_focus=true
- Passing build with the new: https://github.com/GriceTurrble/galenrice.com/runs/5790781891?check_suite_focus=true

## Description

<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

e.g. Fixes #(issue)
-->

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [x] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [ ] I have tested this feature in the browser

### Test Configuration

- Browser type & version:
- Operating system:
- Ruby version: <!-- by running: `ruby -v` -->
- Bundler version: <!-- by running: `bundle -v`-->
- Jekyll version: <!-- by running: `bundle list | grep " jekyll "` -->

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
