### PR TITLE
feat: horizontal scroll for long equations

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -126,6 +126,11 @@ blockquote {
   @include prompt("danger", "\f071");
 }
 
+mjx-container {
+  overflow: auto;
+  padding: 0.5rem 0;
+}
+
 kbd {
   font-family: inherit;
   display: inline-block;


### PR DESCRIPTION
# Description

<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Currently, long equations rendered by MathJax tend to overflow the post content onto the right side navigational toc and on phones, they get completely cut off. PR introduces a horizontal scroll for along equations.  

Fixes #543 

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

I specified a long equation detailed below

```markdown
$$
(a + b)^3 = {3 \choose 0} a^3 b^0 + {3 \choose 1} a^2 b^1 + {3 \choose 2} a^1 b^2 + {3 \choose 0} a^0 b^3 + 0 \left ({3 \choose 0} a^3 b^0 + {3 \choose 1} a^2 b^1 + {3 \choose 2} a^1 b^2 + {3 \choose 0} a^0 b^3 \right )
$$
```

This equation currently runs over the navigation toc in the browser and gets completely cut off on the phone as described in the feature request: #543 

Post making the changes in this PR, a disappearing horizontal scroll appears for long equation. 

- [x] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Safari (15.4) and Google Chrome (Version 99.0.4844.84 (Official Build) (x86_64))
- Operating system: macOS Monterey (12.3)
- Ruby version: <!-- by running: `ruby -v` --> ruby 2.6.8p205
- Bundler version: <!-- by running: `bundle -v`--> Bundler version 1.17.2
- Jekyll version: <!-- by running: `bundle list | grep " jekyll "` --> jekyll (4.2.2)

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
