### PR TITLE
Adding `strip` to the avatar on relative files

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -13,7 +13,7 @@
             {% elsif site.img_cdn != empty and site.img_cdn %}
               {{ site.avatar | prepend: site.img_cdn }}
             {% else %}
-              {{ site.avatar | relative_url }}
+              {{ site.avatar | strip | relative_url }}
             {% endif %}
           {% endcapture %}
           <img src="{{ avatar_url | strip }}" alt="avatar" onerror="this.style.display='none'">


### PR DESCRIPTION
## Description

In testing I found that the avatar resolution when referring to assets was failing out before it hit the img tag because the `relative_url` could not resolve `<whatever>/<lots of space>\n<more space>\n`. Adding a `| strip` to the resolution fixes it.  The other cases get the same behavior later.

To replicate it: 

1. Put an avatar file in `assets/images`.
2. Add `assets/images` to the defaults in _config.yml.
3. Refer to the avatar file in the `avatar` tag in _config.yml.
4. Reload the website.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

I followed the process above with a local site and found it working. 

- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Safari on iOS 15
- Operating system: iOS 15
- Ruby version: 2.7.5p203
- Bundler version: 2.3.11
- Jekyll version: 4.1.1

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas (not applicable) 
- [ ] I have made corresponding changes to the documentation (not needed)
- [x] My changes generate no new warnings
