### PR TITLE
 fix: assets 404 when baseurl isn't empty and assets is 'self_host'

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -68,7 +68,7 @@
       <link rel="dns-prefetch" href="{{ cdn.url }}" {{ cdn.args }}>
     {% endfor %}
 
-    <link rel="stylesheet" href="{{ site.data.assets[origin].webfonts }}">
+    <link rel="stylesheet" href="{{ site.data.assets[origin].webfonts | relative_url }}">
 
   {% endif %}
 
@@ -90,25 +90,25 @@
   {% endif %}
 
   <!-- Bootstrap -->
-  <link rel="stylesheet" href="{{ site.data.assets[origin].bootstrap.css }}">
+  <link rel="stylesheet" href="{{ site.data.assets[origin].bootstrap.css | relative_url}}">
 
   <!-- Font Awesome -->
-  <link rel="stylesheet" href="{{ site.data.assets[origin].fontawesome.css }}">
+  <link rel="stylesheet" href="{{ site.data.assets[origin].fontawesome.css | relative_url }}">
 
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
 
   {% if site.toc and page.toc %}
-    <link rel="stylesheet" href="{{ site.data.assets[origin].bootstrap-toc.css }}">
+    <link rel="stylesheet" href="{{ site.data.assets[origin].bootstrap-toc.css | relative_url }}">
   {% endif %}
 
   {% if page.layout == 'page' or page.layout == 'post' %}
     <!-- Manific Popup -->
-    <link rel="stylesheet" href="{{ site.data.assets[origin].magnific-popup.css }}">
+    <link rel="stylesheet" href="{{ site.data.assets[origin].magnific-popup.css | relative_url }}">
   {% endif %}
 
   <!-- JavaScript -->
 
-  <script src="{{ site.data.assets[origin].jquery.js }}"></script>
+  <script src="{{ site.data.assets[origin].jquery.js | relative_url }}"></script>
 
   {% unless site.theme_mode %}
     {% include mode-toggle.html %}

--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -7,7 +7,7 @@
 {% if page.layout == 'post' %}
   {% if site.google_analytics.pv.proxy_endpoint or site.google_analytics.pv.cache_path %}
     <!-- pv-report needs countup.js -->
-    <script async src="{{ site.data.assets[origin].countup.js }}"></script>
+    <script async src="{{ site.data.assets[origin].countup.js | relative_url }}"></script>
     <script defer src="{{ '/assets/js/dist/pvreport.min.js' | relative_url }}"></script>
   {% endif %}
 {% endif %}
@@ -79,14 +79,14 @@
     }
   };
   </script>
-  <script src="{{ site.data.assets[origin].polyfill.js }}"></script>
-  <script id="MathJax-script" async src="{{ site.data.assets[origin].mathjax.js }}">
+  <script src="{{ site.data.assets[origin].polyfill.js | relative_url }}"></script>
+  <script id="MathJax-script" async src="{{ site.data.assets[origin].mathjax.js | relative_url }}">
   </script>
 {% endif %}
 
 <!-- commons -->
 
-<script src="{{ site.data.assets[origin].bootstrap.js }}"></script>
+<script src="{{ site.data.assets[origin].bootstrap.js | relative_url }}"></script>
 
 {% if jekyll.environment == 'production' %}
   <!-- PWA -->

--- a/_includes/mermaid.html
+++ b/_includes/mermaid.html
@@ -2,7 +2,7 @@
   mermaid-js loader
 -->
 
-<script src="{{ site.data.assets[origin].mermaid.js }}"></script>
+<script src="{{ site.data.assets[origin].mermaid.js | relative_url }}"></script>
 
 <script>
   $(function() {

--- a/_includes/search-loader.html
+++ b/_includes/search-loader.html
@@ -16,7 +16,7 @@
 
 {% capture not_found %}<p class="mt-5">{{ site.data.locales[lang].search.no_results }}</p>{% endcapture %}
 
-<script src="{{ site.data.assets[origin].search.js }}"></script>
+<script src="{{ site.data.assets[origin].search.js | relative_url }}"></script>
 
 <script>
 SimpleJekyllSearch({

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -7,7 +7,7 @@
 
 {% if enable_toc %}
 <!-- BS-toc.js will be loaded at medium priority -->
-<script src="{{ site.data.assets[origin].bootstrap-toc.js }}"></script>
+<script src="{{ site.data.assets[origin].bootstrap-toc.js | relative_url }}"></script>
 
 <div id="toc-wrapper" class="pl-0 pr-4 mb-5">
   <div class="panel-heading pl-3 pt-2 mb-2">{{- site.data.locales[lang].panel.toc -}}</div>


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

e.g. Fixes #(issue)
-->

Fixes: Some assets is 404 when baseurl isn't empty and assets is 'self_host'

```yml
baseurl: /i-am-not-empty
assets:
  self_host: true
    enabled:      # boolean, keep empty means false
    # specify the Jekyll environment, empty means both
    # only works if `assets.self_host.enabled` is 'true'
    env:          # [development|production]
```

![image](https://user-images.githubusercontent.com/18041500/171345377-eee6df6b-9381-48e8-ad56-9faf0855ca92.png)


## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: chrome
- Operating system: win10
- Ruby version: ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x64-mingw-ucrt] <!-- by running: `ruby -v` -->
- Bundler version: Bundler version 2.3.14 <!-- by running: `bundle -v`-->
- Jekyll version:   * jekyll (4.2.2) <!-- by running: `bundle list | grep " jekyll "` -->

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
