### PR TITLE
Fix typo in English locale file

### DIFF
--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -20,7 +20,7 @@ tabs:
 search:
   hint: search
   cancel: Cancel
-  no_results: Oops! No result founds.
+  no_results: Oops! No results found.
 
 panel:
   lastmod: Recently Updated


### PR DESCRIPTION
## Description

Fixes a minor typo in the English locale.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Firefox 101.0
- Operating system: Windows 10
- Ruby version: 2.7.3
- Bundler version: 2.2.20
- Jekyll version: 4.2.2

### Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
