### PR TITLE
fix: typo in Hungarian locale file

### DIFF
--- a/_data/locales/hu-HU.yml
+++ b/_data/locales/hu-HU.yml
@@ -77,9 +77,5 @@ post:
 
 # categories page
 categories:
-  category_measure:
-    singular: kategória
-    plural: kategória
-  post_measure:
-    singular: bejegyzés
-    plural: bejegyzés
+  category_measure: kategória
+  post_measure: bejegyzés

--- a/_data/locales/hu-HU.yml
+++ b/_data/locales/hu-HU.yml
@@ -79,7 +79,7 @@ post:
 categories:
   category_measure:
     singular: kategória
-    plural: kategóriák
+    plural: kategória
   post_measure:
     singular: bejegyzés
-    plural: bejegyzések
+    plural: bejegyzés


### PR DESCRIPTION
## Description

In the 'mighty' hungarian language we don't use plurals after numbers. This will fix it on the Categories page.

<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

e.g. Fixes #(issue)
-->

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version:
- Operating system:
- Ruby version: <!-- by running: `ruby -v` -->
- Bundler version: <!-- by running: `bundle -v`-->
- Jekyll version: <!-- by running: `bundle list | grep " jekyll "` -->

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
