### PR TITLE
fix: added top margins to content

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,8 +27,15 @@ layout: compress
 
     <div id="main-wrapper" class="d-flex justify-content-center">
       <div id="main" class="container pl-xl-4 pr-xl-4">
+        <div class="row">
+          <div id="core-wrapper">
+              <div class="mt-5">
 
-        {{ content }}
+                  {{ content }}
+                  
+              </div>
+            </div>
+        </div>
 
         {% include footer.html %}
 


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

e.g. Fixes #(issue)
-->

As I mentioned in #600 issue, the content slides below the top menu in default layout. Added top margins before the content.

Default layout page with top margin:

![image](https://user-images.githubusercontent.com/39780892/173128202-3d947b5f-8d1f-47dc-8e87-15293e808410.png)

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Microsoft Edge 102.0.1245.33
- Operating system: Windows 10
- Ruby version: ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x64-mingw-ucrt]
- Bundler version: 2.3.15
- Jekyll version: jekyll 4.2.2

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
