### PR TITLE
adding a note about preview images and 5.2.0

### DIFF
--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -248,7 +248,7 @@ Except for `alt`, all other options are necessary, especially the `width` and `h
 
 Starting from _Chirpy v5.0.0_, the attributes `height` and `width` can be abbreviated: `height` → `h`, `width` → `w`. In addition, the [`img_path`](#image-path) can also be passed to the preview image, that is, when it has been set, the  attribute `path` only needs the image file name.
 
-Starting from _Chirpy v5.2.0_, the property for the preview image changes from `image.src` to `image.path`. If upgrading the theme from a prior version, you will have to update posts' metadata to use new image property.
+Starting from _Chirpy v5.2.0_, the property for the preview image is changed to `image.path`. If upgrading the theme from a prior version, you will have to update posts' metadata to use new image property.
 
 ## Pinned Posts
 

--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -248,6 +248,8 @@ Except for `alt`, all other options are necessary, especially the `width` and `h
 
 Starting from _Chirpy v5.0.0_, the attributes `height` and `width` can be abbreviated: `height` → `h`, `width` → `w`. In addition, the [`img_path`](#image-path) can also be passed to the preview image, that is, when it has been set, the  attribute `path` only needs the image file name.
 
+Starting from _Chirpy v5.2.0_, the property for the preview image changes from `image.src` to `image.path`. If upgrading the theme from a prior version, you will have to update posts' metadata to use new image property.
+
 ## Pinned Posts
 
 You can pin one or more posts to the top of the home page, and the fixed posts are sorted in reverse order according to their release date. Enable by:


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

e.g. Fixes #(issue)
-->

Adding a note in the writing a post markdown to make it clear for those upgrading themes that they will need to update their preview images.

See #625

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Documentation update

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [x] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version:
- Operating system:
- Ruby version: <!-- by running: `ruby -v` -->
- Bundler version: <!-- by running: `bundle -v`-->
- Jekyll version: <!-- by running: `bundle list | grep " jekyll "` -->

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
