### PR TITLE
feat(math): better and more customized math support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -132,6 +132,8 @@ kramdown:
     block:
       line_numbers: true
       start_line: 1
+  math_engine: ~ # tell kramdown to leave math expressions alone, otherwise kramdown will 
+                 # automatically convert delimiters like "\[", "$$" to something unwanted.
 
 collections:
   tabs:

--- a/_data/assets/cross_origin.yml
+++ b/_data/assets/cross_origin.yml
@@ -53,10 +53,10 @@ lozad:
   js: https://cdn.jsdelivr.net/npm/lozad/dist/lozad.min.js
 
 clipboard:
-  js:  https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js
+  js: https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js
 
 polyfill:
   js: https://polyfill.io/v3/polyfill.min.js?features=es6
 
 mathjax:
-  js: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js
+  js: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg-full.js

--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -64,24 +64,7 @@
 
 {% if page.math %}
   <!-- MathJax -->
-  <script>
-  /* see: <https://docs.mathjax.org/en/latest/options/input/tex.html#tex-options> */
-  MathJax = {
-    tex: {
-      inlineMath: [              /* start/end delimiter pairs for in-line math */
-        ['$','$'],
-        ['\\(','\\)']
-      ],
-      displayMath: [             /* start/end delimiter pairs for display math */
-        ['$$', '$$'],
-        ['\\[', '\\]']
-      ]
-    }
-  };
-  </script>
-  <script src="{{ site.data.assets[origin].polyfill.js | relative_url }}"></script>
-  <script id="MathJax-script" async src="{{ site.data.assets[origin].mathjax.js | relative_url }}">
-  </script>
+  {% include math.html %}
 {% endif %}
 
 <!-- commons -->

--- a/_includes/math.html
+++ b/_includes/math.html
@@ -1,0 +1,10 @@
+<!-- polyfill -->
+<script src="{{ site.data.assets[origin].polyfill.js | relative_url }}"></script>
+<!-- MathJax configuration -->
+<script src="{{ '/assets/js/math.js' | relative_url }}" defer></script>
+<!-- MathJax -->
+<script
+  id="MathJax-script"
+  src="{{ site.data.assets[origin].mathjax.js | relative_url }}"
+  defer
+></script>

--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -131,6 +131,13 @@ mjx-container {
   overflow-y: hidden;
 }
 
+/* display math */
+span.kdmath > mjx-container {
+  display: block;
+  text-align: center;
+  margin: 1rem;
+}
+
 kbd {
   font-family: inherit;
   display: inline-block;

--- a/assets/js/math.js
+++ b/assets/js/math.js
@@ -1,6 +1,9 @@
 /* see: <https://docs.mathjax.org/en/latest/options/input/tex.html#tex-options> */
 MathJax = {
   tex: {
+    packages: {
+      "[+]": ["noundefined", "autoload", "ams", "textmacros", "physics"],
+    },
     inlineMath: [
       /* start/end delimiter pairs for in-line math */
       ["$", "$"],
@@ -11,5 +14,6 @@ MathJax = {
       ["$$", "$$"],
       ["\\[", "\\]"],
     ],
+    tags: "none", // or 'ams' or 'all'
   },
 };

--- a/assets/js/math.js
+++ b/assets/js/math.js
@@ -1,0 +1,15 @@
+/* see: <https://docs.mathjax.org/en/latest/options/input/tex.html#tex-options> */
+MathJax = {
+  tex: {
+    inlineMath: [
+      /* start/end delimiter pairs for in-line math */
+      ["$", "$"],
+      ["\\(", "\\)"],
+    ],
+    displayMath: [
+      /* start/end delimiter pairs for display math */
+      ["$$", "$$"],
+      ["\\[", "\\]"],
+    ],
+  },
+};


### PR DESCRIPTION
## Description

1. Separate MathJax configuration to `/assets/js/math.js` for convenient customization.
2. Provide a more powerful ( more packages ) and better rendering setup of MathJax.

MathJax configuration in inline `<script>` does not work from time to time. Therefore I extract it into a separate `math.js`. I'm not sure if I put the code in the right place, please let me know if I'm wrong.

Here is a live [demo](https://blog.liblaf.top/demo/2021/09/04/mathjax-v3-with-tex-input-and-svg-output/). "physics" package really speedup writing math equations :)

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [x] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Firefox 102.0.1 (64-bit)
- Operating system: Ubuntu 22.04 LTS
- Ruby version: 2.7.6p219 (2022-04-12 revision c9c2245c0a) [x86_64-linux]
- Bundler version: 2.3.18
- Jekyll version: 4.2.2

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
