### PR TITLE
changed variable heading in module.scss

### DIFF
--- a/_sass/addon/module.scss
+++ b/_sass/addon/module.scss
@@ -4,7 +4,7 @@
 
 /* ---------- scss placeholder --------- */
 
-%heading {
+%heading, %heading > a {
   color: var(--heading-color);
   font-weight: 400;
   font-family: 'Lato', 'Microsoft Yahei', sans-serif;


### PR DESCRIPTION
## Description

The button of theme selection (light and dark) doesn't changing the heading post color (because they are inside a tag link 'a'), causing visual problems with light and dark theme, depeding the color wich is configured.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

Just run the project and see the color of the heading posts changing according to the heading pattern color.
Before, the heading in scss module.scss doesn't aply the color in the subsequents heading links.

- [x] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [x ] I have tested this feature in the browser

### Test Configuration

- Browser type & version:
- Operating system:
- Ruby version: ruby 2.7.0p0
- Bundler version: Bundler version 2.3.18
- Jekyll version: 
              st | grep " jekyll "
                * jekyll (4.2.2)

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
