### PR TITLE
Fix deploy action failing if submodules present

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -84,6 +84,7 @@ setup_gh() {
 backup() {
   mv "$SITE_DIR"/* "$_backup_dir"
   mv .git "$_backup_dir"
+  mv .gitmodules "$_backup_dir"
 
   # When adding custom domain from Github website,
   # the CANME only exist on `gh-pages` branch

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -84,7 +84,9 @@ setup_gh() {
 backup() {
   mv "$SITE_DIR"/* "$_backup_dir"
   mv .git "$_backup_dir"
-  mv .gitmodules "$_backup_dir"
+  if [[ -f ".gitmodules" ]]; then
+    mv .gitmodules "$_backup_dir"
+  fi
 
   # When adding custom domain from Github website,
   # the CANME only exist on `gh-pages` branch


### PR DESCRIPTION

## Description
Fixes Github actions not finding submodules when using the `tools/deploy.sh` script. Fix based on suggestion in #640 

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested

- [x] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version:
- Operating system:
- Ruby version: 3.0.2p107 (2021-07-07 revision 0db68f0233)
- Bundler version: 2.3.19
- Jekyll version: 4.2.2

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
