### PR TITLE
fix: linkedin icon color doesn't exist when user use linkedin in share.yml

### DIFF
--- a/_sass/layout/post.scss
+++ b/_sass/layout/post.scss
@@ -293,6 +293,10 @@ nav[data-toggle=toc] {
         @include btn-sharing-color(rgb(39, 159, 217));
       }
 
+      &.fa-linkedin {
+        @include btn-sharing-color(rgb(0, 119, 181));
+      }
+
       &.fa-weibo {
         @include btn-sharing-color(rgb(229, 20, 43));
       }


### PR DESCRIPTION
## Description
When users want to use Linkedin and Weibo for sharing by uncommenting them in share.yml, the LinkedIn icon doesn't have its color, whereas Weibo has its color. Turned out that Linkedin's icon color is missing in post.scss.
![image](https://user-images.githubusercontent.com/39375111/188902087-c667d65e-c633-43d5-b46c-36ef3d8412b3.png)

Solution:
Add Linkedin color in post.scss, the color is based on LinkedIn's official brand color:
https://brand.linkedin.com/content/brand/global/en_us/index/visual-identity/color-palettes
![image](https://user-images.githubusercontent.com/39375111/188902460-7645185b-42fa-4686-b1b0-d42ca2138cbf.png)

<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

e.g. Fixes #(issue)
-->

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/deploy.sh --dry-run` (at the root of the project) locally and passed
- [X] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Google Chrome Version 104.0.5112.102 (Official Build) (64-bit)
- Operating system: Windows 11
- Ruby version: ruby 3.1.2p20
- Bundler version: Bundler version 2.3.21
- Jekyll version: jekyll (4.2.2)

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [X] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
