### PR TITLE
Removing extra padding in nested lists

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -76,14 +76,6 @@ h5 {
   font-size: 1.1rem;
 }
 
-ol,
-ul {
-  ol,
-  ul {
-    margin-bottom: 1rem;
-  }
-}
-
 a {
   @extend %link-color;
 }
@@ -468,6 +460,25 @@ img[data-src] {
 
   }
 
+  > ol,
+  > ul {
+    $start-padding: 1.25rem;
+
+    padding-inline-start: $start-padding;
+    margin: 1.25rem 0;
+
+    li {
+      margin: 0.5rem 0;
+      padding-left: 0.4rem;
+    }
+
+    ol,
+    ul {
+      padding-inline-start: $start-padding;
+      margin: 0.75rem 0;
+    }
+  }
+
   ul {
     /* attribute 'hide-bullet' was added by liquid */
     .task-list-item[hide-bullet] {
@@ -491,26 +502,6 @@ img[data-src] {
     }
 
   } /* ul */
-
-  > ol,
-  > ul {
-    padding-left: 2rem;
-
-    li {
-      ol,
-      ul { /* sub list */
-        padding-left: 2rem;
-        margin-top: 0.3rem;
-      }
-    }
-
-  }
-
-  > ol {
-    li {
-      padding-left: 0.25em;
-    }
-  }
 
   dl > dd {
     margin-left: 1rem;


### PR DESCRIPTION
Closes https://github.com/cotes2020/jekyll-theme-chirpy/issues/702

## Description

<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

e.g. Fixes #(issue)
-->

Removing extra padding in nested lists

From:

![image](https://user-images.githubusercontent.com/19912012/193879385-5b28ab5f-8e1d-4084-b1ef-332e2339ba51.png)

To:

![image](https://user-images.githubusercontent.com/19912012/193888403-65ab77f0-fc5b-4c68-8a00-08fb1af317de.png)


This reflects more of how it looks like in GitHub:

- Coffee
- Tea
    * Black tea
    * Green tea
- Milk

## Type of change

<!-- 
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

(Depending on how you look at this, could be bug, could be feature 🤷 )

## How has this been tested

<!-- 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [x] I have run `bash ./tools/test.sh` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

Tested with latest `master` branch

### Test Configuration

- Browser type & version: Chrome latest
- Operating system: macOS latest
- Ruby version: <!-- by running: `ruby -v` --> ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
- Bundler version: <!-- by running: `bundle -v`--> Bundler version 2.3.7
- Jekyll version: <!-- by running: `bundle list | grep " jekyll "` --> jekyll (4.2.2)

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
