### PR TITLE
chore(giscus): Add reactions_enabled parameter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -99,13 +99,14 @@ comments:
     issue_term:   # < url | pathname | title | ...>
   # Giscus options › https://giscus.app
   giscus:
-    repo:             # <gh-username>/<repo>
+    repo:              # <gh-username>/<repo>
     repo_id:
     category:
     category_id:
-    mapping:          # optional, default to 'pathname'
-    input_position:   # optional, default to 'bottom'
-    lang:             # optional, default to the value of `site.lang`
+    mapping:           # optional, default to 'pathname'
+    input_position:    # optional, default to 'bottom'
+    lang:              # optional, default to the value of `site.lang`
+    reactions_enabled: # optional, default to the value of `1`
 
 # Self-hosted static assets, optional › https://github.com/cotes2020/chirpy-static-assets
 assets:

--- a/_includes/comments/giscus.html
+++ b/_includes/comments/giscus.html
@@ -20,7 +20,7 @@
       "data-category": "{{ site.comments.giscus.category }}",
       "data-category-id": "{{ site.comments.giscus.category_id }}",
       "data-mapping": "{{ site.comments.giscus.mapping | default: 'pathname' }}",
-      "data-reactions-enabled": "1",
+      "data-reactions-enabled": "{{ site.comments.giscus.reactions_enabled | default: '1' }}",
       "data-emit-metadata": "0",
       "data-theme": initTheme,
       "data-input-position": "{{ site.comments.giscus.input_position | default: 'bottom' }}",


### PR DESCRIPTION
## Description

Add `reactions_enabled` parameter for giscus to allow users to enable/disable reactions.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update