### PR TITLE
perf(css): apply styles to lists inside blockquote

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -461,8 +461,8 @@ img[data-src] {
     }
   }
 
-  > ol,
-  > ul {
+  ol,
+  ul {
     -webkit-padding-start: 1.75rem;
     padding-inline-start: 1.75rem;
 
@@ -473,8 +473,8 @@ img[data-src] {
 
     ol,
     ul {
-      -webkit-padding-start: 1rem;
-      padding-inline-start: 1rem;
+      -webkit-padding-start: 1.25rem;
+      padding-inline-start: 1.25rem;
       margin: 0.5rem 0;
     }
   }


### PR DESCRIPTION
## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

e.g. Fixes #(issue)
-->

`.post-content { >ol, >ul ...` prevents the styles from being applied to the lists inside blockquote. 

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [x] I have run `bash ./tools/test.sh` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Google Chrome 107.0.5304.68
- Operating system: Ubuntu 22.04
- Ruby version: <!-- by running: `ruby -v` -->3.0.2p107
- Bundler version: <!-- by running: `bundle -v`-->2.3.5
- Jekyll version: <!-- by running: `bundle list | grep " jekyll "` -->4.2.2

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
