### PR TITLE
Showing home and tab icons in the sidebar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,8 @@ description: >-                        # used by seo meta and the atom feed
 # fill in the protocol & hostname for your site, e.g., 'https://username.github.io'
 url: ''
 
+homeicon: false            # show home icon in sidebar
+
 github:
   username: github_username             # change to your github username
 

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -33,7 +33,7 @@
     <!-- home -->
     <li class="nav-item{% if page.layout == 'home' %}{{ " active" }}{% endif %}">
       <a href="{{ '/' | relative_url }}" class="nav-link">
-        <i class="fa-fw fas fa-home ml-xl-3 mr-xl-3 unloaded"></i>
+        {% if site.homeicon != empty and site.homeicon %}<i class="fa-fw fas fa-home ml-xl-3 mr-xl-3"></i>{% endif %}
         <span>{{ site.data.locales[site.lang].tabs.home | upcase }}</span>
       </a>
     </li>
@@ -41,7 +41,7 @@
     {% for tab in site.tabs %}
     <li class="nav-item{% if tab.url == page.url %}{{ " active" }}{% endif %}">
       <a href="{{ tab.url | relative_url }}" class="nav-link">
-        <i class="fa-fw {{ tab.icon }} ml-xl-3 mr-xl-3 unloaded"></i>
+        {% if tab.icon != empty %}<i class="fa-fw {{ tab.icon }} ml-xl-3 mr-xl-3"></i>{% endif %}
         {% capture tab_name %}{{ tab.url | split: '/' }}{% endcapture %}
 
         <span>{{ site.data.locales[site.lang].tabs.[tab_name] | default: tab.title | upcase }}</span>


### PR DESCRIPTION
## Description

Since Chirpy already contains the icons that are hidden I added the code to hide them only in certain (default) conditions.
Fixes #745 


## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

`homeicon` setting can be ether empty or `false` to keep icon hidden, and `true` to show it.
Icons next to tabs only show if the tabs contain a set `icon` property.

I tested by customizing the `sidebar.html` in my repo that used chirpy-starter.

- [ ] I have run `bash ./tools/test.sh` (at the root of the project) locally and passed
- [ ] I have tested this feature in the browser

### Test Configuration

- Browser type & version:
- Operating system:
- Ruby version: <!-- by running: `ruby -v` -->
- Bundler version: <!-- by running: `bundle -v`-->
- Jekyll version: <!-- by running: `bundle list | grep " jekyll "` -->

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
