### PR TITLE
Create toggle.html

### DIFF
--- a/_includes/toggle.html
+++ b/_includes/toggle.html
@@ -1,0 +1,5 @@
+<details>
+    <summary>{{ summary | markdownify | remove: '<p>' | remove: '</p>' }}</summary>
+    {{ details | markdownify }}
+  <hr>
+</details><p></p>


### PR DESCRIPTION
Hide a part of text in posts

## Description

Hide a part of text in posts

i have to note that I dont have experience in Jekyll and my provided information is not professional

Also, there is a tweak (CSS) to change the color of this toggle part which makes it adorable -> [link](https://css-tricks.com/put-a-background-on-open-details-elements/)

thanks a lot

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

[link to live version](http://card.alerezaa.ir/jekyll-theme-chirpy/posts/text-and-typography/#hide-text)

- [x] I have run `bash ./tools/test.sh` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

Github defaults -> [link to file](https://github.com/alerezaaa/jekyll-theme-chirpy/blob/patch-1/.github/workflows/jekyll.yml)

- Browser type & version:
- Operating system:
- Ruby version: 3.0
- Bundler version: ?
- Jekyll version: ?

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
