### PR TITLE
feat: add custom sidebar title support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,8 @@ timezone: Asia/Shanghai
 
 title: Chirpy                          # the main title
 
+sidebar_title:                         # the title in the sidebar (uses title if left blank)
+
 tagline: A text-focused Jekyll theme   # it will display as the sub-title
 
 description: >-                        # used by seo meta and the atom feed

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -22,7 +22,7 @@
     </div>
 
     <div class="site-title">
-      <a href="{{ '/' | relative_url }}">{{ site.title }}</a>
+      <a href="{{ '/' | relative_url }}">{{ site.sidebar_title | default: site.title }}</a>
     </div>
     <div class="site-subtitle font-italic">{{ site.tagline }}</div>
 


### PR DESCRIPTION
## Description
I need to have a sidebar title text that is different with site title.

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/test.sh` (at the root of the project) locally and passed
- [X] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Google Chrome	107.0.5304.110 (Official Build) (arm64)
- Operating system: macOS 13.0.1 (22A400)
- Ruby version: 3.1.0
- Bundler version: 2.3.15
- Jekyll version: 4.3.1

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
