### PR TITLE
docs: Add dubious ownership error handle document

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ $ docker run -it --rm \
     jekyll serve
 ```
 
+If you encounter with the following error at docker
+```console
+fatal: detected dubious ownership in repository at
+```
+Please use the following command
+```console
+$ docker run -it --rm \
+    --volume="$PWD:/srv/jekyll" \
+    -p 4000:4000 jekyll/jekyll \
+    sh -c "git config --system --add safe.directory '*' && \
+    jekyll serve"
+```
+
 After a while, navigate to the site at <http://localhost:4000>.
 
 ## Documentation

--- a/_posts/2019-08-09-getting-started.md
+++ b/_posts/2019-08-09-getting-started.md
@@ -95,6 +95,19 @@ $ docker run -it --rm \
     jekyll serve
 ```
 
+If you encounter with the following error at docker
+```console
+fatal: detected dubious ownership in repository at
+```
+Please use the following command
+```console
+$ docker run -it --rm \
+    --volume="$PWD:/srv/jekyll" \
+    -p 4000:4000 jekyll/jekyll \
+    sh -c "git config --system --add safe.directory '*' && \
+    jekyll serve"
+```
+
 After a while, the local service will be published at _<http://127.0.0.1:4000>_.
 
 ## Deployment
@@ -139,6 +152,20 @@ $ docker run -it --rm \
     --volume="$PWD:/srv/jekyll" \
     jekyll/jekyll \
     jekyll build
+```
+
+If you encounter with the following error at docker
+```console
+fatal: detected dubious ownership in repository at
+```
+Please use the following command
+```console
+$ docker run -it --rm \
+    --env JEKYLL_ENV=production \
+    --volume="$PWD:/srv/jekyll" \
+    jekyll/jekyll \
+    sh -c "git config --system --add safe.directory '*' && \
+    jekyll build"
 ```
 
 Unless you specified the output path, the generated site files will be placed in folder `_site`{: .filepath} of the project's root directory. Now you should upload those files to the target server.


### PR DESCRIPTION
## Description
In local docker environment,
The post `updated timestamp` will not show up if the repository owner is not current user 
This issue will only happen after git 2.35.2

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

e.g. Fixes #(issue)
-->

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How has this been tested

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [x] I have run `bash ./tools/test.sh` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version:
- Operating system: `Linux 5.15.0-56-generic #62-Ubuntu SMP Tue Nov 22 19:54:14 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux`
- Ruby version: `ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux-gnu]`
- Bundler version: `Bundler version 2.3.26`
- Jekyll version: `* jekyll (4.3.1)`

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
