### PR TITLE
feat: add rel="me" to Mastodon sidebar contact links for verification

### DIFF
--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -19,7 +19,7 @@
 # -
 #   type: mastodon
 #   icon: 'fab fa-mastodon'   # icons powered by <https://fontawesome.com/>
-#   url:  ''                  # Fill with your mastodon account page
+#   url:  ''                  # Fill with your Mastodon account page, rel="me" will be applied for verification
 # -
 #   type: linkedin
 #   icon: 'fab fa-linkedin'   # icons powered by <https://fontawesome.com/>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -81,7 +81,17 @@
 
       {% if url %}
       <a href="{{ url }}" aria-label="{{ entry.type }}"
-        {% unless entry.noblank %}target="_blank" rel="noopener"{% endunless %}>
+        {% assign link_types = nil %}
+        {% unless entry.noblank %}
+          {% assign link_types = link_types | append: " noopener" %}
+          target="_blank"
+        {% endunless %}
+
+        {% if entry.type == 'mastodon' %}
+          {% assign link_types = link_types | append: " me" %}
+        {% endif %}
+
+        {% if link_types %}rel="{{ link_types | lstrip }}"{% endif %}>
         <i class="{{ entry.icon }}"></i>
       </a>
       {% endif %}


### PR DESCRIPTION
## Description

This will enable verification with Mastodon by including the `rel="me"` attribute.
https://docs.joinmastodon.org/user/profile/#verification

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested

- ~~[ ] I have run `bash ./tools/test.sh` (at the root of the project) locally and passed~~ tested via https://github.com/kendaleiv/jekyll-theme-chirpy/pull/1
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Edge 108
- Operating system: Windows 10
- Ruby version: ruby 3.1.2p20
- Bundler version: 2.3.7
- Jekyll version: 4.3.1

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (no changes needed?)
- [x] My changes generate no new warnings
