### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,5 @@ end
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
+
+gem "jekyll-sass-converter", "~> 2.0"


### PR DESCRIPTION
## Description
I updated my theme to 5.4.0 and I faced a problem, building failed

```
2022-12-28T15:10:07.319174Z	[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set path '/opt/buildhome/cache/bundle'`, and stop using this flag
2022-12-28T15:10:07.466315Z	[DEPRECATED] The --binstubs option will be removed in favor of `bundle binstubs`
2022-12-28T15:10:09.841137Z	Fetching gem metadata from https://rubygems.org/...........
2022-12-28T15:10:10.034838Z	Fetching gem metadata from https://rubygems.org/.
2022-12-28T15:10:10.139023Z	Resolving dependencies...
2022-12-28T15:10:10.183369Z	sass-embedded-1.57.1-x86_64-linux-gnu requires rubygems version >= 3.3.22, which
2022-12-28T15:10:10.183674Z	is incompatible with the current version, 3.1.2
2022-12-28T15:10:10.226477Z	Error during gem install
2022-12-28T15:10:10.232119Z	Failed: build command exited with code: 1
2022-12-28T15:10:11.091504Z	Failed: an internal error occurred
```

After googling I found the solution:
[source](https://community.cloudflare.com/t/deployment-failing-rubygems-version/446483)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How has this been tested


- [x] I have deployed my website using online providers
- [ ] I have run `bash ./tools/test` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version:
- Operating system:
- Ruby version: <!-- by running: `ruby -v` -->
- Bundler version: <!-- by running: `bundle -v`-->
- Jekyll version: <!-- by running: `bundle list | grep " jekyll "` -->

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

---
<details>
  <summary>full log:</summary>

  ```shell
  2022-12-28T15:09:49.386636Z	Cloning repository...
  2022-12-28T15:09:50.636846Z	From https://github.com/alerezaaa/Jekyll_CF-Mine
  2022-12-28T15:09:50.637393Z	 * branch            e00e138d23d40a36f7bf7058565419ffd8d224b5 -> FETCH_HEAD
  2022-12-28T15:09:50.637599Z	
  2022-12-28T15:09:50.697333Z	HEAD is now at e00e138 Update Gemfile
  2022-12-28T15:09:50.697922Z	
  2022-12-28T15:09:52.489406Z	Submodule 'assets/lib' (https://github.com/cotes2020/chirpy-static-assets.git) registered for path 'assets/lib'
  2022-12-28T15:09:52.490002Z	Cloning into '/opt/buildhome/clone/assets/lib'...
  2022-12-28T15:09:52.49026Z	Submodule path 'assets/lib': checked out 'd1d2ec17c88176753d4dd2a1296620021dcc22fd'
  2022-12-28T15:09:52.490447Z	
  2022-12-28T15:09:52.521724Z	Success: Finished cloning repository files
  2022-12-28T15:09:53.207455Z	Installing dependencies
  2022-12-28T15:09:53.218751Z	Python version set to 2.7
  2022-12-28T15:09:55.174086Z	Attempting node version '15.14.0' from .node-version
  2022-12-28T15:09:56.626409Z	Downloading and installing node v15.14.0...
  2022-12-28T15:09:57.055344Z	Downloading https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-x64.tar.xz...
  2022-12-28T15:09:57.797607Z	Computing checksum with sha256sum
  2022-12-28T15:09:57.92477Z	Checksums matched!
  2022-12-28T15:10:02.109523Z	Now using node v15.14.0 (npm v7.7.6)
  2022-12-28T15:10:02.525913Z	Started restoring cached build plugins
  2022-12-28T15:10:02.539471Z	Finished restoring cached build plugins
  2022-12-28T15:10:03.085292Z	Attempting ruby version 2.7.1, read from environment
  2022-12-28T15:10:06.687351Z	Using ruby version 2.7.1
  2022-12-28T15:10:07.036402Z	Using PHP version 5.6
  2022-12-28T15:10:07.037008Z	Started restoring cached ruby gems
  2022-12-28T15:10:07.052299Z	Finished restoring cached ruby gems
  2022-12-28T15:10:07.052808Z	Installing gem bundle
  2022-12-28T15:10:07.319174Z	[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set path '/opt/buildhome/cache/bundle'`, and stop using this flag
  2022-12-28T15:10:07.466315Z	[DEPRECATED] The --binstubs option will be removed in favor of `bundle binstubs`
  2022-12-28T15:10:09.841137Z	Fetching gem metadata from https://rubygems.org/...........
  2022-12-28T15:10:10.034838Z	Fetching gem metadata from https://rubygems.org/.
  2022-12-28T15:10:10.139023Z	Resolving dependencies...
  2022-12-28T15:10:10.183369Z	sass-embedded-1.57.1-x86_64-linux-gnu requires rubygems version >= 3.3.22, which
  2022-12-28T15:10:10.183674Z	is incompatible with the current version, 3.1.2
  2022-12-28T15:10:10.226477Z	Error during gem install
  2022-12-28T15:10:10.232119Z	Failed: build command exited with code: 1
  2022-12-28T15:10:11.091504Z	Failed: an internal error occurred
  ```

</details>
