### PR TITLE
Do not trim whitespaces in md

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,8 @@ trim_trailing_whitespace = true
 end_of_line = lf
 insert_final_newline = true
 
-
 [*.js]
 indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Description

Option `trim_trailing_whitespace` in `.editorconfig` is switched on globally which is wrong because two trailing spaces has special meaning in `md` files.

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/test` (at the root of the project) locally and passed
- [ x] I have tested this feature in the browser

### Test Configuration

- Browser type & version:
- Operating system: Ubuntu Linux
- Ruby version: 3.0.2
- Bundler version: 2.3.5
- Jekyll version: 4.3.1

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
