### PR TITLE
fix: replace special characters with '%*' in sharing URLs

### DIFF
--- a/_includes/post-sharing.html
+++ b/_includes/post-sharing.html
@@ -10,7 +10,7 @@
 
     {% for share in site.data.share.platforms %}
       {% assign link = share.link | replace: 'TITLE', title | replace: 'URL', url %}
-        <a href="{{ link }}" data-toggle="tooltip" data-placement="top"
+        <a href="{{ link | uri_escape }}" data-toggle="tooltip" data-placement="top"
           title="{{ share.type }}" target="_blank" rel="noopener" aria-label="{{ share.type }}">
           <i class="fa-fw {{ share.icon }}"></i>
         </a>


### PR DESCRIPTION
## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

e.g. Fixes #(issue)
-->
fix cotes2020#835

I've tried to use `url_encode`, but it replaces spaces with `+`. Therefore I finally use the `uri_escape`.

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [x] I have run `bash ./tools/test` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Chrome 108.0.5359.124
- Operating system: Ubuntu 22.04
- Ruby version: <!-- by running: `ruby -v` -->3.0.2p107
- Bundler version: <!-- by running: `bundle -v`-->2.3.13
- Jekyll version: <!-- by running: `bundle list | grep " jekyll "` -->4.3.1

### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
