### PR TITLE
Update sidebar.html

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -82,10 +82,10 @@
       {% if url %}
       <a href="{{ url }}" aria-label="{{ entry.type }}"
         {% assign link_types = nil %}
-        {% unless entry.noblank %}
+        {% if entry.noblank %}
           {% assign link_types = link_types | append: " noopener" %}
           target="_blank"
-        {% endunless %}
+        {% endif %}
 
         {% if entry.type == 'mastodon' %}
           {% assign link_types = link_types | append: " me" %}


### PR DESCRIPTION
changed unless entry.noblank to an if statement.  This was introducing nooperner and me within the same href link.

## Description
bug: #875 
entry.noblank was generating the incorrect rel="me" href link.  Updating to an if block resolved the problem producing the following href.
Current:
`<a href="https://twit.social/@ebmarquez" aria-label="mastodon" target="_blank" rel="noopener me">`


New:

`<a href="https://twit.social/@ebmarquez" aria-label="mastodon" rel="me">`

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

e.g. Fixes #(issue)
-->

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested
Generated this on my live site and with the local build. the HTML for the link was checked.  The link continues to work and it has the correct syntax.

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [x] I have run `bash ./tools/test` (at the root of the project) locally and passed
```bash
Running ["LinkCheck", "ImageCheck", "HtmlCheck", "ScriptCheck"] on ["_site"] on *.html... 

Ran on 35 files!

HTML-Proofer finished successfully.
```
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version:
  - Edge Version 111.0.1652.0 (Official build) dev (64-bit)
  - Edge Version 109.0.1518.78 (Official build) (64-bit)
  - Firefox 109.0.1 (64-bit)
  - Chrome Version 109.0.5414.120 (Official Build) (64-bit)
- Operating system:
Windows 11 - Microsoft Windows 10.0.22623
- Ruby version: <!-- by running: `ruby -v` -->
  `ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x86_64-linux]`

- Bundler version: <!-- by running: `bundle -v`-->
`Bundler version 2.3.26`

- Jekyll version: <!-- by running: `bundle list | grep " Jekyll "` -->
`Jekyll (4.3.2)`
### Checklist

<!-- Select checkboxes by change the "[ ]" to "[x]" -->
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
