### PR TITLE
add support for adsense ads at the bottom of posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
   - Search
   - Atom Feeds
   - Google Analytics
+  - Google Adsense
   - Page Views Reporting
   - SEO & Performance Optimization
 

--- a/_config.yml
+++ b/_config.yml
@@ -60,6 +60,11 @@ google_analytics:
     proxy_endpoint:   # fill in the Google Analytics superProxy endpoint of Google App Engine
     cache_path:       # the local PV cache data, friendly to visitors from GFW region
 
+google_adsense:
+  client_id: ca-pub-0000000000000000         # adsense client id, ex: ca-pub-0000000000000000
+  slot_id: 0000000000           # adsense slot id, ex: 0000000000
+  enabled: false
+
 # Prefer color scheme setting.
 #
 # Note: Keep empty will follow the system prefer color by default,

--- a/_includes/adsense.html
+++ b/_includes/adsense.html
@@ -1,0 +1,17 @@
+{% if site.google_adsense and site.google_adsense.enabled %}
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={{ site.google_adsense.client_id }}"></script>
+<ins class="adsbygoogle"
+     style="display:block"
+     data-ad-client="{{ site.google_adsense.client_id }}"
+     data-ad-slot="{{ site.google_adsense.slot_id }}"
+     data-ad-format="auto"
+     data-full-width-responsive="true"
+     {% unless jekyll.environment == "production" %}
+     data-ad-test="on"
+     {% endunless %}
+>
+</ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -138,4 +138,6 @@ tail_includes:
 
   </div><!-- .post-tail-bottom -->
 
+  {% include adsense.html %}
+
 </div><!-- div.post-tail-wrapper -->

--- a/_posts/2023-03-14-enable-google-adsense.md
+++ b/_posts/2023-03-14-enable-google-adsense.md
@@ -1,0 +1,41 @@
+---
+title: Enable Google Adsense
+author: acdoussan
+date: 2023-03-14 17:00:00 -0500
+categories: [Blogging, Tutorial]
+tags: [google adsense, adsense, ads, advertisements, advertisement, google]
+---
+
+
+This post is to enable Adsense on the [**Chirpy**][chirpy-homepage] theme based blog that you just built. This requires technical knowledge.
+
+NOTE: If your blog isn't served at the root of your domain (aka www.example.com or example.com), adsense won't approve
+your account. There is no way around this. If you want to set this up on a subdomain, serve your blog on both and
+redirect www and no prefix to your blog while adsense is validating your domain. You can remove the redirect after, but
+there is no guaruntee that they won't re-review and stop serving ads on your domain.
+
+## Set up Google Adsense
+
+See https://support.google.com/adsense/answer/7402253?hl=en for how to create an adsense account.
+
+Navigate to the Sites tab on the left and enter in a domain for your blog, follow the prompts to create the site.
+When you get the example code, save it or note down the client id and slot id.
+
+## Configure Chirpy to serve ads
+
+Update the `_config.yml`{: .filepath} file of [**Chirpy**][chirpy-homepage] project with the following values, use the
+example code from creating the domain to fill in these values:
+
+```yaml
+google_adsense:
+  client_id: ca-pub-0000000000000000
+  slot_id: 8435997133
+  enabled: true
+```
+{: file="_config.yml"}
+
+Publish this change to your blog, and start the adsense verification process. Once your site is approved, visitors
+should start getting shown ads!
+## Reference
+
+[chirpy-homepage]: https://github.com/cotes2020/jekyll-theme-chirpy/


### PR DESCRIPTION
## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

e.g. Fixes #(issue)
-->

Implements https://github.com/cotes2020/jekyll-theme-chirpy/issues/669

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [x] I have run `bash ./tools/test` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser
- [x] I have made these changes on my local blog, deployed it, and gotten my adsense account approved and ads are being served

### Test Configuration

- Browser type & version: Chrome
- Operating system: macOS
- Ruby version: <!-- by runnbing: `ruby -v` --> ruby 3.1.2p20
- Bundler version: <!-- by running: `bundle -v`--> Bundler version 2.1.4b
- Jekyll version: <!-- by running: `bundle list | grep " jekyll "` --> jekyll (4.3.2)
