### PR TITLE
Solve a bug in Disqus

### DIFF
--- a/_includes/comments/disqus.html
+++ b/_includes/comments/disqus.html
@@ -1,41 +1,39 @@
-<!--
-  The Disqus lazy loading.
--->
+<!-- The Disqus lazy loading. -->
 <div id="disqus_thread" class="pt-2 pb-2">
-  <p class="text-center text-muted small">
-    Comments powered by <a href="https://disqus.com/">Disqus</a>.
-  </p>
+  <p class="text-center text-muted small">Comments powered by <a href="https://disqus.com/">Disqus</a>.</p>
 </div>
 
 <script type="text/javascript">
-
   var disqus_config = function () {
     this.page.url = '{{ page.url | absolute_url }}';
     this.page.identifier = '{{ page.url }}';
   };
 
   /* Lazy loading */
-  var disqus_observer = new IntersectionObserver(function (entries) {
-    if(entries[0].isIntersecting) {
+  var disqus_observer = new IntersectionObserver(
+    function (entries) {
+      if (entries[0].isIntersecting) {
         (function () {
-            var d = document, s = d.createElement('script');
-            s.src = 'https://{{ site.comments.disqus.shortname }}.disqus.com/embed.js';
-            s.setAttribute('data-timestamp', +new Date());
-            (d.head || d.body).appendChild(s);
+          var d = document,
+            s = d.createElement('script');
+          s.src = 'https://{{ site.comments.disqus.shortname }}.disqus.com/embed.js';
+          s.setAttribute('data-timestamp', +new Date());
+          (d.head || d.body).appendChild(s);
         })();
 
         disqus_observer.disconnect();
-    }
-  }, { threshold: [0] });
+      }
+    },
+    { threshold: [0] }
+  );
 
   disqus_observer.observe(document.querySelector('#disqus_thread'));
 
   /* Auto switch theme */
   function reloadDisqus() {
-    if (event.source === window && event.data &&
-      event.data.direction === ModeToggle.ID) {
+    if (event.source === window && event.data && event.data.direction === ModeToggle.ID) {
       /* Disqus hasn't been loaded */
-      if (typeof DISQUS === "undefined") {
+      if (typeof DISQUS === 'undefined') {
         return;
       }
 
@@ -45,10 +43,7 @@
     }
   }
 
-  const modeToggle = document.querySelector(".mode-toggle");
-
-  if (typeof modeToggle !== "undefined") {
-    window.addEventListener("message", reloadDisqus);
+  if (document.querySelector('.mode-toggle')) {
+    window.addEventListener('message', reloadDisqus);
   }
-
 </script>


### PR DESCRIPTION
## Description

Disqus can't be loaded due to an uncaught syntax error: Identifier 'modeToggle' has already been declared at elsewhere. The solution is to use another name.

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/test` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version: Chrome
- Operating system: MacOS
- Ruby version: <!-- by running: `ruby -v` -->
- Bundler version: <!-- by running: `bundle -v`-->
- Jekyll version: <!-- by running: `bundle list | grep " jekyll "` -->
