### PR TITLE
feat: make fonts customizable

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -34,7 +34,7 @@ body {
     env(safe-area-inset-bottom) env(safe-area-inset-left);
   color: var(--text-color);
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro', 'Microsoft Yahei', sans-serif;
+  font-family: $font-family-base;
   line-height: 1.75;
 }
 

--- a/_sass/addon/module.scss
+++ b/_sass/addon/module.scss
@@ -7,7 +7,7 @@
 %heading {
   color: var(--heading-color);
   font-weight: 400;
-  font-family: Lato, 'Microsoft Yahei', sans-serif;
+  font-family: $font-family-heading;
 }
 
 %section {

--- a/_sass/addon/variables.scss
+++ b/_sass/addon/variables.scss
@@ -28,3 +28,8 @@ $bottom-min-height: 35rem !default;
 /* syntax highlight */
 
 $code-font-size: 0.85rem !default;
+
+/* fonts */
+
+$font-family-base: 'Source Sans Pro', 'Microsoft Yahei', sans-serif;
+$font-family-heading: Lato, 'Microsoft Yahei', sans-serif;

--- a/_sass/jekyll-theme-chirpy.scss
+++ b/_sass/jekyll-theme-chirpy.scss
@@ -10,9 +10,9 @@
   "colors/light-typography",
   "colors/dark-typography",
 
-  "addon/module",
   "addon/variables",
   "variables-hook",
+  "addon/module",
   "addon/syntax",
   "addon/commons",
 


### PR DESCRIPTION
## Description

Move the font family and font size of the body and headings into `variables.scss` so that making them be more easily customizable for users.

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/test` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

### Test Configuration

- Browser type & version:
- Operating system:
- Ruby version: <!-- by running: `ruby -v` -->
- Bundler version: <!-- by running: `bundle -v`-->
- Jekyll version: <!-- by running: `bundle list | grep " jekyll "` -->
