### PR TITLE
perf(tools): avoid initialization interruption in single branch forks

### DIFF
--- a/tools/init
+++ b/tools/init
@@ -77,9 +77,9 @@ check_env() {
   _check_init
 }
 
-checkout_latest_tag() {
-  tag=$(git describe --tags "$(git rev-list --tags --max-count=1)")
-  git reset --hard "$tag"
+checkout_latest_release() {
+  hash=$(git log --grep="chore(release):" -1 --pretty="%H")
+  git reset --hard "$hash"
 }
 
 init_files() {
@@ -114,7 +114,7 @@ commit() {
 
 main() {
   check_env
-  checkout_latest_tag
+  checkout_latest_release
   init_files
   commit
 }


### PR DESCRIPTION
## Description

When a fork chooses to only copy the `master` branch, initialization tool will be interrupted due to the lack of git-tag information.

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Improvement (refactoring and improving code)


## Additional context

<!-- e.g. Fixes #(issue) -->

## How has this been tested

Run the init-tool with single branch.
