### PR TITLE
feat: allow users to define custom metadata

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -113,4 +113,7 @@
   {% unless site.theme_mode %}
     {% include mode-toggle.html %}
   {% endunless %}
+
+  {% include metadata-hook.html %}
+
 </head>

--- a/_includes/metadata-hook.html
+++ b/_includes/metadata-hook.html
@@ -1,0 +1,1 @@
+<!-- A placeholder to allow defining custom metadata -->


### PR DESCRIPTION
## Description

This new feature allows users to define custom metadata in the `<head>` without overriding the whole `head.html`. They just need to put their metadata into `custom-head.html`, then the metadata would be automatically included into the `<head>`. 

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Additional context

<!-- e.g. Fixes #(issue) -->

## How has this been tested

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/test` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser
