### PR TITLE
Minor new feature:  For blog posts, the "Updated xxxx" datetime is displayed next to the Posted datetime even if not desired.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,7 +21,7 @@ tail_includes:
     </span>
 
     <!-- lastmod date -->
-    {% if page.last_modified_at %}
+    {% if page.last_modified_at and page.last_modified_at != page.date %}
     <span>
       {{ site.data.locales[lang].post.updated }}
       {% include datetime.html date=page.last_modified_at tooltip=true lang=lang %}


### PR DESCRIPTION
## Description
There is the current (although somewhat hidden) ability to set "last_modified_at: " in the front matter of a post to use a user-specified datetime instead of the built in logic.

New feature in post.html:  if the modified date time matches the date of the post, then don't show "Updated xxxx"

This is useful when bringing in old posts and you don't want the 'updated xxx' to display today's date on a 3 year old post.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Additional context
One-liner improvement to post.html

## How has this been tested
- [ ] I have run `bash ./tools/test` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser

Validation:
3 types of blog posts:
1) Front matter without `last_modified_at` specified  (unchanged: current display logic occurs)
2) Front matter with `last_modified_at` not matching `date` (unchanged: display logic uses specified value)
3) Front matter with `last_modified_at` matching `date`  (new: Updated does not display)
