### PR TITLE
Resume the shimmer effect of image links

### DIFF
--- a/_includes/refactor-content.html
+++ b/_includes/refactor-content.html
@@ -1,6 +1,4 @@
-<!--
-  Refactor the HTML structure.
--->
+<!-- Refactor the HTML structure -->
 
 {% assign _content = include.content %}
 
@@ -44,9 +42,9 @@
 {% endif %}
 
 <!-- images -->
+{% assign IMG_TAG = '<img ' %}
 
-{% if _content contains '<img' %}
-  {% assign IMG_TAG = '<img ' %}
+{% if _content contains IMG_TAG %}
   {% assign _img_content = nil %}
   {% assign _img_snippets = _content | split: IMG_TAG %}
 
@@ -160,7 +158,15 @@
     <!-- Bypass the HTML-proofer test -->
     {% assign _left = _left | append: ' data-proofer-ignore' %}
 
-    {% if page.layout == 'post' %}
+    {% if page.layout == 'home' %}
+      <!-- create the image wrapper -->
+      {%- capture _wrapper_start -%}
+        <div class="preview-img {{ _class | strip }}">
+      {%- endcapture -%}
+      {% assign _img_content = _img_content | append: _wrapper_start %}
+      {% assign _right = _right | prepend: '></div' %}
+
+    {% else %}
       <!-- make sure the `<img>` is wrapped by `<a>` -->
       {% assign _parent = _right | slice: 1, 4 %}
 
@@ -179,16 +185,6 @@
         {% assign _img_content = _img_content | append: _wrapper_start %}
         {% assign _right = _right | prepend: '></a' %}
       {% endif %}
-
-    {% endif %}
-
-    {% if page.layout == 'home' %}
-      <!-- create the image wrapper -->
-      {%- capture _wrapper_start -%}
-        <div class="preview-img {{ _class | strip }}">
-      {%- endcapture -%}
-      {% assign _img_content = _img_content | append: _wrapper_start %}
-      {% assign _right = _right | prepend: '></div' %}
     {% endif %}
 
     <!-- combine -->


### PR DESCRIPTION
## Description

Image links have a shimmer effect when loading, but this effect was accidentally lost in the development of _v6.0.0_ (97b8dfe). 

This commit brings it back up again.

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)


## Additional context

<!-- e.g. Fixes #(issue) -->

## How has this been tested

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [x] I have run `bash ./tools/test` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser
