### PR TITLE
Fix the margin at the bottom of the main content area

### DIFF
--- a/_includes/post-paginator.html
+++ b/_includes/post-paginator.html
@@ -1,6 +1,6 @@
 <!-- The paginator for post list on HomgPage. -->
 
-<ul class="pagination align-items-center my-4 ps-lg-2">
+<ul class="pagination align-items-center mt-4 mb-1 ps-lg-2">
   <!-- left arrow -->
   {% if paginator.previous_page %}
     {% assign prev_url = paginator.previous_page_path | relative_url %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -5,7 +5,11 @@ layout: default
 {% include lang.html %}
 {% include origin-type.html %}
 
-<div class="row">
+{% if layout.tail_includes %}
+  {% assign has_tail = true %}
+{% endif %}
+
+<div class="row{% unless has_tail %} mb-5{% endunless %}">
   <!-- core -->
   <div id="core-wrapper" class="col-12 col-lg-11 col-xl-9 pe-xl-4">
     {% capture padding %}
@@ -52,7 +56,7 @@ layout: default
 </div>
 
 <!-- tail -->
-{% if layout.tail_includes %}
+{% if has_tail %}
   <div class="row">
     <div id="tail-wrapper" class="col-12 col-lg-11 col-xl-9 px-3 pe-xl-4 mt-5">
       {% for _include in layout.tail_includes %}

--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -1113,10 +1113,6 @@ $btn-mb: 0.5rem;
       @extend %no-bottom-border;
     }
   }
-
-  @at-root .row:only-child > #{&} {
-    padding-bottom: 3rem;
-  }
 }
 
 #mask {

--- a/_sass/layout/home.scss
+++ b/_sass/layout/home.scss
@@ -5,10 +5,6 @@
 #post-list {
   margin-top: 2rem;
 
-  &:only-child {
-    margin-bottom: 3.75rem;
-  }
-
   a.card-wrapper {
     display: block;
 


### PR DESCRIPTION
## Description

Restore the margin at the bottom of the main content area that was lost in _v6.0.0_.

In a way, this is a fix for d81f836

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)

## Additional context

Commit d81f836

## How has this been tested

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [x] I have run `bash ./tools/test` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser
