### PR TITLE
Remove dead SCSS code

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -290,16 +290,6 @@ i {
       margin-top: 0;
       margin-bottom: 0;
     }
-
-    /* [scroll-focus] added by `smooth-scroll.js` */
-    &:target:not([scroll-focus]),
-    &[scroll-focus='true'] > p {
-      background-color: var(--footnote-target-bg);
-      width: -moz-fit-content;
-      width: -webkit-fit-content;
-      width: fit-content;
-      transition: background-color 1.5s ease-in-out;
-    }
   }
 }
 
@@ -310,12 +300,6 @@ i {
 
     border-bottom-style: none !important;
     transition: background-color 1.5s ease-in-out;
-  }
-
-  /* [scroll-focus] added by `smooth-scroll.js` */
-  @at-root sup:target:not([scroll-focus]),
-    sup[scroll-focus='true'] > a#{&} {
-    background-color: var(--footnote-target-bg);
   }
 }
 


### PR DESCRIPTION
## Description

In _v6.0.0_, some unused SCSS code was left behind when the top bar collapsing feature was deprecated.



## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->

- [x] Improvement (refactoring and improving code)

## Additional context

<!-- e.g. Fixes #(issue) -->

## How has this been tested

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [x] I have run `bash ./tools/test` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser
