### PR TITLE
The CJK characters of the "Search Cancel" button will wrap

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -957,7 +957,7 @@ $btn-mb: 0.5rem;
 /* 'Cancel' link */
 #search-cancel {
   color: var(--link-color);
-  margin-left: 1rem;
+  margin-left: 0.75rem;
   display: none;
   white-space: nowrap;
 

--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -959,6 +959,7 @@ $btn-mb: 0.5rem;
   color: var(--link-color);
   margin-left: 1rem;
   display: none;
+  white-space: nowrap;
 
   @extend %cursor-pointer;
 }


### PR DESCRIPTION
## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
H5 search cancel text arranges vertically when lang switched to zh-CN. I think it is a bug.

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [x] Bug fix (non-breaking change which fixes an issue)

## Additional context

<!-- e.g. Fixes #(issue) -->

## How has this been tested

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
- follow the [contribution doc](https://github.com/cotes2020/jekyll-theme-chirpy/blob/master/.github/CONTRIBUTING.md)，fork the project and clone it locally
- install deps
- change`_config.yml`: `lang: en` to `lang: zh-CN`
- run `npm run build && bundle exec jekyll serve`
- view in chrome devtool with mobile mode, click search icon, you will see "取消" arranging vertically at right side
- with this commit, reproduce above steps and get the correct render result.

- [x] I have run `bash ./tools/test` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser
