### PR TITLE
fix: image preview display error when image.alt includes '<' or '>'

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -54,7 +54,7 @@ refactor: true
             {% assign src = post.img_path | append: '/' | append: src | replace: '//', '/' %}
           {% endunless %}
 
-         {% assign alt = post.image.alt | xml_escape | default: 'Preview Image' %}
+          {% assign alt = post.image.alt | xml_escape | default: 'Preview Image' %}
 
           <img src="{{ src }}" w="15" h="8" alt="{{ alt }}" {{ lqip }}>
         {% endif %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -54,7 +54,7 @@ refactor: true
             {% assign src = post.img_path | append: '/' | append: src | replace: '//', '/' %}
           {% endunless %}
 
-          {% assign alt = post.image.alt | default: 'Preview Image' %}
+          {% assign alt = post.image.alt | default: 'Preview Image' | replace: '<', '&lt;' | replace: '>', '&gt;' %}
 
           <img src="{{ src }}" w="15" h="8" alt="{{ alt }}" {{ lqip }}>
         {% endif %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -54,7 +54,7 @@ refactor: true
             {% assign src = post.img_path | append: '/' | append: src | replace: '//', '/' %}
           {% endunless %}
 
-          {% assign alt = post.image.alt | default: 'Preview Image' | replace: '<', '&lt;' | replace: '>', '&gt;' %}
+         {% assign alt = post.image.alt | xml_escape | default: 'Preview Image' %}
 
           <img src="{{ src }}" w="15" h="8" alt="{{ alt }}" {{ lqip }}>
         {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -31,7 +31,7 @@ tail_includes:
   {% if page.image %}
     {% capture src %}src="{{ page.image.path | default: page.image }}"{% endcapture %}
     {% capture class %}class="preview-img{% if page.image.no_bg %}{{ ' no-bg' }}{% endif %}"{% endcapture %}
-    {% capture alt %}alt="{{ page.image.alt | default: "Preview Image" }}"{% endcapture %}
+    {% capture alt %}alt="{{ page.image.alt | default: "Preview Image" | replace: "<", "&lt;" | replace: ">", "&gt;" }}"{% endcapture %}
 
     {% capture lqip %}
       {% if page.image.lqip %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -31,7 +31,7 @@ tail_includes:
   {% if page.image %}
     {% capture src %}src="{{ page.image.path | default: page.image }}"{% endcapture %}
     {% capture class %}class="preview-img{% if page.image.no_bg %}{{ ' no-bg' }}{% endif %}"{% endcapture %}
-    {% capture alt %}alt="{{ page.image.alt | default: "Preview Image" | replace: "<", "&lt;" | replace: ">", "&gt;" }}"{% endcapture %}
+    {% capture alt %}alt="{{ page.image.alt | xml_escape | default: "Preview Image" }}"{% endcapture %}
 
     {% capture lqip %}
       {% if page.image.lqip %}


### PR DESCRIPTION
## Description

### Describe the bug
When specifying a preview image in a post,  
if you specify a value of < or > for `alt`, the image will not display properly because it encroaches on the HTML tag range.

### To Reproduce

1. Create a new post.
2. In the post properties, write image.alt to contain < or >, as follows

- example
```yml
image:
  path: /commons/devices-mockup.png
  alt: get device image -> show mockup
```

### Expected behavior && Logs/Screenshots

- At Home (root path)
<img width="785" alt="image" src="https://github.com/cotes2020/jekyll-theme-chirpy/assets/13290706/6c429a6a-6c2a-4978-9407-55c20447d580">  

- At Post
<img width="825" alt="image" src="https://github.com/cotes2020/jekyll-theme-chirpy/assets/13290706/ea907c08-d701-4d08-9f2b-13729da1b45d">


## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Additional context

<!-- e.g. Fixes #(issue) -->

## How has this been tested

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [X] I have run `bash ./tools/test` (at the root of the project) locally and passed
- [X] I have tested this feature in the browser
