### PR TITLE
Update commons.scss icon for prompt-info

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -151,7 +151,7 @@ blockquote {
   }
 
   @include prompt('tip', '\f0eb', 'regular');
-  @include prompt('info', '\f06a');
+  @include prompt('info', '\f05a');
   @include prompt('warning', '\f06a');
   @include prompt('danger', '\f071');
 }


### PR DESCRIPTION
## Description

Both the icons for .prompt-info and .promt-warning are '\f06a'. But the icon for .prompt-info should be '\f05a' (circle-info from fontawesome), not '\f06a' (circle-exclamation).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
