### PR TITLE
docs: fix incorrect platform include

### DIFF
--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -394,13 +394,13 @@ Or adding `render_with_liquid: false` (Requires Jekyll 4.0 or higher) to the pos
 You can embed a video with the following syntax:
 
 ```liquid
-{% include embed/{Platform}.html id='{ID}' %}
+{% include embed/<Platform>.html id='{ID}' %}
 ```
-Where `Platform` is the lowercase of the platform name, and `ID` is the video ID.
+Where `<Platform>` is the lowercase of the platform name, and `ID` is the video ID.
 
 The following table shows how to get the two parameters we need in a given video URL, and you can also know the currently supported video platforms.
 
-| Video URL                                                                                          | Platform  | ID            |
+| Video URL                                                                                          | \<Platform\>  | ID            |
 |----------------------------------------------------------------------------------------------------|-----------|:--------------|
 | [https://www.**youtube**.com/watch?v=**H-B46URT4mg**](https://www.youtube.com/watch?v=H-B46URT4mg) | `youtube` | `H-B46URT4mg` |
 | [https://www.**twitch**.tv/videos/**1634779211**](https://www.twitch.tv/videos/1634779211)         | `twitch`  | `1634779211`  |


### PR DESCRIPTION
The previous description in the documentation  implied that the full syntax would be the following which is incorrect.
```
{% include embed/{youtube}.html id='{H-B46URT4mg}' %}
```

Using the above snippet will lead to the following error message when attempting to serve the site.

```
Invalid syntax for include tag. File contains invalid characters or sequences: (ArgumentError)

  embed/{youtube}.html

Valid syntax:  {% include file.ext param='value' param2='value' %}
```

This slight alteration should make it clear that the correct syntax is 
```
{% include embed/youtube.html id='{H-B46URT4mg}' %}
```

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Type of change

<!--
Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Additional context

<!-- e.g. Fixes #(issue) -->

## How has this been tested

The edited document was previewed on Github's document Preview feature. It has not been ran locally.

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] I have run `bash ./tools/test` (at the root of the project) locally and passed
- [ ] I have tested this feature in the browser

No tests were run beyond previewing the edited document.