### PR TITLE
Speed up the Jekyll build times for large sites

### DIFF
--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -1,7 +1,4 @@
-<!--
-  Recommend the other 3 posts according to the tags and categories of the current post,
-  if the number is not enough, use the other latest posts to supplement.
--->
+<!-- Recommend the other 3 posts according to the tags and categories of the current post. -->
 
 <!-- The total size of related posts -->
 {% assign TOTAL_SIZE = 3 %}
@@ -14,11 +11,23 @@
 
 {% assign SEPARATOR = ':' %}
 
+{% assign match_posts = '' | split: '' %}
+
+{% for category in page.categories %}
+  {% assign temp = site.posts | where_exp: 'item', 'item.categories contains category' %}
+  {% assign match_posts = match_posts | push: temp %}
+{% endfor %}
+
+{% for tag in page.tags %}
+  {% assign temp = site.posts | where_exp: 'item', 'item.categories contains tag' %}
+  {% assign match_posts = match_posts | push: temp %}
+{% endfor %}
+
+{% assign last_index = match_posts.size | minus: 1 %}
 {% assign score_list = '' | split: '' %}
-{% assign last_index = site.posts.size | minus: 1 %}
 
 {% for i in (0..last_index) %}
-  {% assign post = site.posts[i] %}
+  {% assign post = match_posts[i] %}
 
   {% if post.url == page.url %}
     {% continue %}
@@ -54,34 +63,20 @@
   {% endfor %}
 {% endif %}
 
-<!-- Fill with the other newlest posts -->
-{% assign less = TOTAL_SIZE | minus: index_list.size %}
+{% assign relate_posts = '' | split: '' %}
 
-{% if less > 0 %}
-  {% for i in (0..last_index) %}
-    {% assign post = site.posts[i] %}
-    {% if post.url != page.url %}
-      {% capture cur_index %}{{ i }}{% endcapture %}
-      {% unless index_list contains cur_index %}
-        {% assign index_list = index_list | push: cur_index %}
-        {% assign less = less | minus: 1 %}
-        {% if less <= 0 %}
-          {% break %}
-        {% endif %}
-      {% endunless %}
-    {% endif %}
-  {% endfor %}
-{% endif %}
+{% for index in index_list %}
+  {% assign i = index | to_integer %}
+  {% assign relate_posts = relate_posts | push: match_posts[i] %}
+{% endfor %}
 
-{% if index_list.size > 0 %}
+{% if relate_posts.size > 0 %}
   <div id="related-posts" class="mb-2 mb-sm-4">
     <h3 class="pt-2 mb-4 ms-1" data-toc-skip>
       {{ site.data.locales[include.lang].post.relate_posts }}
     </h3>
     <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 mb-4">
-      {% for entry in index_list %}
-        {% assign index = entry | plus: 0 %}
-        {% assign post = site.posts[index] %}
+      {% for post in relate_posts %}
         <div class="col">
           <a href="{{ post.url | relative_url }}" class="card post-preview h-100">
             <div class="card-body">


### PR DESCRIPTION
## Description

If the site has a large number of posts, and a lot of metadata (`categories` and `tags` from posts), then rendering the `_includes/related-posts.html` will be a bottleneck in build time.

### Practical example:

With 1082 posts, 94 categories, and 26 tags, on a machine configured with Intel Core i7 CPU and 16GB RAM, the site's build time details are as follows:

```
Build Process Summary:

| PHASE    |     TIME |
+----------+----------+
| RESET    |   0.0003 |
| READ     |  34.1979 |
| GENERATE |   0.1318 |
| RENDER   | 123.6652 |
| CLEANUP  |   0.1728 |
| WRITE    |   0.7328 |


Site Render Stats:

| Filename                                                                                  | Count |     Bytes |    Time |
+-------------------------------------------------------------------------------------------+-------+-----------+---------+
| _layouts/page.html                                                                        |  1319 | 53683.56K | 107.046 |
| _includes/related-posts.html                                                              |  1085 | 31899.44K | 104.668 |
| _layouts/default.html                                                                     |  1319 | 87090.83K |   8.098 |
| _includes/head.html                                                                       |  1319 | 15723.82K |   4.609 |
| _layouts/home.html                                                                        |   109 |  2953.91K |   4.168 |
| _layouts/post.html                                                                        |  1085 |  7249.28K |   2.390 |
| _includes/js-selector.html                                                                |  1319 |  1149.73K |   1.207 |
| _includes/sidebar.html                                                                    |  1319 |  4068.55K |   1.203 |
| _includes/post-paginator.html                                                             |   109 |  1086.50K |   1.085 |
| _includes/datetime.html                                                                   |  7383 |  1248.77K |   0.881 |
| _includes/read-time.html                                                                  |  1085 |   293.66K |   0.836 |
| _includes/post-sharing.html                                                               |  1085 |  2381.29K |   0.747 |
| _includes/jsdelivr-combine.html                                                           |  1319 |   873.32K |   0.595 |
| _includes/post-nav.html                                                                   |  1085 |   663.21K |   0.560 |
| _includes/refactor-content.html                                                           |  1196 | 11139.09K |   0.491 |
| _includes/topbar.html                                                                     |  1319 |  1357.49K |   0.356 |
...
| _tabs/about.md                                                                            |     1 |     0.30K |   0.000 |
                    done in 158.944 seconds.
```

## Type of change

- [x] Improvement (refactoring and improving code)

## Additional context

- #1094 
- #1098

## How has this been tested

For the same hardware with the same site files, executing the `bundle exec jekyll b --profile` command results in a significant reduction in build time.

```
Build Process Summary:

| PHASE    |    TIME |
+----------+---------+
| RESET    |  0.0002 |
| READ     | 32.4250 |
| GENERATE |  0.0847 |
| RENDER   | 32.1113 |
| CLEANUP  |  0.2832 |
| WRITE    |  0.8849 |


Site Render Stats:

| Filename                                                                                  | Count |     Bytes |   Time |
+-------------------------------------------------------------------------------------------+-------+-----------+--------+
| _layouts/page.html                                                                        |  1319 | 22114.94K | 17.042 |
| _includes/related-posts.html                                                              |  1085 |   330.82K | 14.423 |
| _layouts/default.html                                                                     |  1319 | 55522.21K |  6.963 |
| _layouts/home.html                                                                        |   109 |  2953.91K |  3.573 |
| _includes/head.html                                                                       |  1319 | 15723.82K |  3.251 |
| _layouts/post.html                                                                        |  1085 |  7249.28K |  2.677 |
| _includes/js-selector.html                                                                |  1319 |  1149.73K |  1.321 |
| _includes/sidebar.html                                                                    |  1319 |  4068.55K |  1.285 |
| _includes/post-paginator.html                                                             |   109 |  1086.50K |  1.097 |
| _includes/read-time.html                                                                  |  1085 |   293.66K |  0.922 |
| _includes/post-sharing.html                                                               |  1085 |  2381.29K |  0.917 |
| _includes/post-nav.html                                                                   |  1085 |   663.21K |  0.784 |
| _includes/jsdelivr-combine.html                                                           |  1319 |   873.32K |  0.663 |
| _includes/refactor-content.html                                                           |  1196 | 11139.09K |  0.530 |
| _includes/datetime.html                                                                   |  4128 |   733.82K |  0.497 |
| _includes/topbar.html                                                                     |  1319 |  1357.49K |  0.380 |
...
| _tabs/about.md                                                                            |     1 |     0.30K |  0.000 |

                    done in 65.825 seconds.
```


