### PR TITLE
Optimize the main block height calculation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,10 +27,10 @@ layout: compress
     {% include sidebar.html lang=lang %}
 
     <div id="main-wrapper" class="d-flex justify-content-center">
-      <div class="container px-xxl-5">
+      <div class="container d-flex flex-column px-xxl-5">
         {% include topbar.html lang=lang %}
 
-        <div class="row">
+        <div class="row flex-grow-1">
           <main
             aria-label="Main Content"
             class="col-12 col-lg-11 col-xl-9 px-md-4{% unless has_tail %} pb-5{% endunless %}"

--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -372,7 +372,6 @@ i {
 
 main {
   line-height: 1.75;
-  min-height: calc(100vh - $topbar-height - $footer-height);
 
   h1 {
     margin-top: 2rem;
@@ -1127,6 +1126,10 @@ search {
   position: relative;
 
   @include pl-pr(0);
+
+  > .container {
+    min-height: 100vh;
+  }
 }
 
 #topbar-wrapper.row,
@@ -1278,10 +1281,6 @@ search {
     } @else {
       transition: $basic;
     }
-  }
-
-  main {
-    min-height: calc(100vh - $topbar-height - $footer-height-large);
   }
 
   footer {


### PR DESCRIPTION
## Type of change

- [x] Improvement (refactoring and improving code)

## Description
If the post content height is smaller than the panel, there will be a large blank space between the bottom of the post and "Further Reading" section.


