### PR TITLE
Resume target highlighting for superscripts and footnotes

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -273,6 +273,8 @@ i {
       margin-bottom: 0.3rem;
     }
 
+    @extend %sup-fn-target;
+
     > p {
       margin-left: 0.25em;
       margin-top: 0;
@@ -287,8 +289,11 @@ i {
     @include pl-pr(2px);
 
     border-bottom-style: none !important;
-    transition: background-color 1.5s ease-in-out;
   }
+}
+
+sup {
+  @extend %sup-fn-target;
 }
 
 .reversefootnote {

--- a/_sass/addon/module.scss
+++ b/_sass/addon/module.scss
@@ -127,6 +127,16 @@
   font-weight: 600;
 }
 
+%sup-fn-target {
+  &:target {
+    background-color: var(--footnote-target-bg);
+    width: -moz-fit-content;
+    width: -webkit-fit-content;
+    width: fit-content;
+    transition: background-color 1.75s ease-in-out;
+  }
+}
+
 /* ---------- scss mixin --------- */
 
 @mixin mt-mb($value) {


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

`<sup>` and `<footnote>` are highlighted when in `:target` state, but this feature has been missing since `v6.1.0` due to an oversight in development.


