### PR TITLE
Avoid LQIP dirty data from the homepage being passed on to the next post

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -47,10 +47,6 @@ layout: default
         {% assign card_body_col = '12' %}
 
         {% if post.image %}
-          {% if post.image.lqip %}
-            {% capture lqip %}lqip="{{ post.image.lqip }}"{% endcapture %}
-          {% endif %}
-
           {% assign src = post.image.path | default: post.image %}
           {% unless src contains '//' %}
             {% assign src = post.img_path | append: '/' | append: src | replace: '//', '/' %}
@@ -59,7 +55,7 @@ layout: default
           {% assign alt = post.image.alt | xml_escape | default: 'Preview Image' %}
 
           <div class="col-md-5">
-            <img src="{{ src }}" alt="{{ alt }}" {{ lqip }}>
+            <img src="{{ src }}" alt="{{ alt }}" {% if post.image.lqip %}lqip="{{ post.image.lqip }}"{% endif %}>
           </div>
 
           {% assign card_body_col = '7' %}


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Assuming that there are two articles on the homepage, and the higher one has an LQIP preview image set up, while the lower one has a preview image without an LQIP, it will be accidentally contaminated by the previous one's LQIP.

This PR fixes the above issue.

