### PR TITLE
feat: add post age notification banner

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -114,6 +114,10 @@ pwa:
 
 paginate: 10
 
+post_age_banner:
+  enabled: true # Enables banner on posts to show age warning
+  age_months: 6 # The age in months for a banner to be shown
+
 # ------------ The following options are not recommended to be modified ------------------
 
 kramdown:

--- a/_includes/post-age-banner.html
+++ b/_includes/post-age-banner.html
@@ -1,0 +1,10 @@
+{% assign post-date = include.post-date | date: "%s" %}
+{% assign last-modified = include.modified-date | date: "%s" %}
+
+<div class="d-none">
+    <div id="posted-date">{{ post-date }}</div>
+    <div id="updated-date">{{ last-modified }}</div>
+    <div id="age-months">{{ include.age }}</div>
+</div>
+
+<blockquote class="d-none prompt-info" id="post-age-banner"></blockquote>

--- a/_includes/post-age-banner.html
+++ b/_includes/post-age-banner.html
@@ -1,10 +1,12 @@
-{% assign post-date = include.post-date | date: "%s" %}
-{% assign last-modified = include.modified-date | date: "%s" %}
+{% if site.post_age_banner.enabled == true %}
+    {% assign post-date = include.post-date | date: "%s" %}
+    {% assign last-modified = include.modified-date | date: "%s" %}
 
-<div class="d-none">
-    <div id="posted-date">{{ post-date }}</div>
-    <div id="updated-date">{{ last-modified }}</div>
-    <div id="age-months">{{ include.age }}</div>
-</div>
+    <div class="d-none">
+        <div id="posted-date">{{ post-date }}</div>
+        <div id="updated-date">{{ last-modified }}</div>
+        <div id="age-months">{{ include.age }}</div>
+    </div>
 
-<blockquote class="d-none prompt-info" id="post-age-banner"></blockquote>
+    <blockquote class="d-none prompt-info" id="post-age-banner"></blockquote>
+{% endif %}

--- a/_javascript/modules/components/post-age-banner.js
+++ b/_javascript/modules/components/post-age-banner.js
@@ -27,6 +27,6 @@ export function postAgeBanner() {
   // If the post age (in months) is greater than 6 (months), then remove the hidden CSS class from the target node, and insert the HTML message
   if (postAgeMonths > ageMonths) {
     postBanner.classList.remove('d-none');
-    postBanner.innerHTML = `This post is ${postAgeMonths} months old. Some information may be outdated or inaccurate.<br>If any updates are required please let us know.`;
+    postBanner.textContent = `This post is ${postAgeMonths} months old. Some information may be outdated or inaccurate.`;
   }
 }

--- a/_javascript/modules/components/post-age-banner.js
+++ b/_javascript/modules/components/post-age-banner.js
@@ -1,0 +1,32 @@
+export function postAgeBanner() {
+
+  // Assign the target node containing the HTML message to a variable
+  let postBanner = document.getElementById('post-age-banner');
+
+  // Read the contents of the 'div' containing the posted date
+  let postDate = Number(document.getElementById('posted-date').innerHTML);
+
+  // Read the contents of the 'div' containing the post's last update date
+  let updatedDate = Number(document.getElementById('updated-date').innerHTML);
+
+  // Read the contents of the 'div' containing the post's last update date
+  let ageMonths = Number(document.getElementById('age-months').innerHTML);
+
+
+  // Check if the updated date is newer than the posted date
+  // if it is then use the updated date, else use the postDate
+  let postCheckDate = updatedDate > postDate ? updatedDate : postDate;
+
+  // Get the current age of the post by subtracting the post's timestamp from the current UNIX timestamp when the page is loaded, i.e. right now
+  let postAge = Math.floor(new Date().getTime() / 1000.0) - postCheckDate;
+
+  // Calculate the age in months by dividing the post's age by the number of seconds in a month, and rounding it down to an integer
+  let postAgeMonths = Math.floor(postAge / 2629746);
+
+
+  // If the post age (in months) is greater than 6 (months), then remove the hidden CSS class from the target node, and insert the HTML message
+  if (postAgeMonths > ageMonths) {
+    postBanner.classList.remove('d-none');
+    postBanner.innerHTML = `This post is ${postAgeMonths} months old. Some information may be outdated or inaccurate.<br>If any updates are required please let us know.`;
+  }
+}

--- a/_javascript/modules/plugins.js
+++ b/_javascript/modules/plugins.js
@@ -4,3 +4,4 @@ export { loadImg } from './components/img-loading';
 export { imgPopup } from './components/img-popup';
 export { initLocaleDatetime } from './components/locale-datetime';
 export { toc } from './components/toc';
+export { postAgeBanner } from './components/post-age-banner';

--- a/_javascript/post.js
+++ b/_javascript/post.js
@@ -4,7 +4,8 @@ import {
   imgPopup,
   initLocaleDatetime,
   initClipboard,
-  toc
+  toc,
+  postAgeBanner
 } from './modules/plugins';
 
 initSidebar();
@@ -15,3 +16,4 @@ initLocaleDatetime();
 initClipboard();
 toc();
 basic();
+postAgeBanner();

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -79,6 +79,10 @@ tail_includes:
   <!-- .post-meta -->
 </header>
 
+<!-- post_age_banner -->
+{% if site.post_age_banner.enabled == true %}
+  {% include post-age-banner.html post-date=page.date modified-date=page.last_modified_at age=site.post_age_banner.age_months %}
+{% endif %}
 <div class="content">
   {{ content }}
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -77,12 +77,13 @@ tail_includes:
     <!-- .d-flex -->
   </div>
   <!-- .post-meta -->
+
+  <!-- post_age_banner -->
+  {% include post-age-banner.html post-date=page.date modified-date=page.last_modified_at age=site.post_age_banner.age_months %}
+
 </header>
 
-<!-- post_age_banner -->
-{% if site.post_age_banner.enabled == true %}
-  {% include post-age-banner.html post-date=page.date modified-date=page.last_modified_at age=site.post_age_banner.age_months %}
-{% endif %}
+
 <div class="content">
   {{ content }}
 </div>


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it to "[x]", then delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->

This change adds a banner to posts over a specified age. Useful for technical bloggers where the data could become out of date over time. 

adds new configuration:

```
post_age_banner:
  enabled: true # Enables banner on posts to show age warning
  age_months: 6 # The age in months for a banner to be shown
```

displays banner:

![image](https://github.com/cotes2020/jekyll-theme-chirpy/assets/159166/e6f032fe-3e2b-43ad-a83b-bf623fe90f0f)


## Additional context
<!-- e.g. Fixes #(issue) -->
