### PR TITLE
perf(ui): render background color before loading preview image

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -315,9 +315,7 @@ sup {
   @extend %rounded;
 
   &:not(.no-bg) {
-    img {
-      background: var(--img-bg);
-    }
+    background: var(--img-bg);
   }
 
   img {


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Improvement (refactoring and improving code)


## Description

When the preview image doesn't load fast enough, the image area goes blank for a short while.

### Before

The background of the preview image is blank, and when the LQIP appears quickly, it causes visual flickering.
 
https://github.com/cotes2020/jekyll-theme-chirpy/assets/11371340/a004213f-440a-4112-95c2-f2d044332010

### After

Rendering the background color before the image is loaded acts as a placeholder and makes it visually smoother.

https://github.com/cotes2020/jekyll-theme-chirpy/assets/11371340/a4b22225-f097-4aa4-9612-501b6ed6bfdb




