### PR TITLE
Add more contents in Mathematics and fix some typo

### DIFF
--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -109,8 +109,8 @@ math: true
 
 After enabling the mathematical feature, you can add math equations with the following syntax: 
 
-- **Block math** should be added with `$$ math $$` *with* **mandatory** blank lines before and after `$$`
-- **Inline math** (in lines) should be added with `$$ math $$` *without* any blank line before or after `$$`
+- **Block math** should be added with `$$ math $$` with **mandatory** blank lines before and after `$$`
+- **Inline math** (in lines) should be added with `$$ math $$` without any blank line before or after `$$`
 - **Inline math** (in lists) should be added with `\$$ math $$`
 
 ```markdown
@@ -129,7 +129,7 @@ $$
 - \$$ LaTeX_math_expression $$
 ```
 
-> Kramdown, the default markdown engine of Jekyll and GitHub, might have some bugs with parsing math blocks with its [default syntax](https://kramdown.gettalong.org/syntax.html#math-blocks). Experiments to reproduce the bug can be found [here](https://zhengyuan-public.github.io/posts/PersonalBlogWithJekyll/#latex-math-equations-in-jekyll). The solutions above have only been tested with [jekyll-theme-chirpy](https://github.com/cotes2020/jekyll-theme-chirpy). 
+The solutions above have only been tested with [jekyll-theme-chirpy](https://github.com/cotes2020/jekyll-theme-chirpy). 
 {: .prompt-info }
 
 ## Mermaid

--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -114,23 +114,22 @@ After enabling the mathematical feature, you can add math equations with the fol
 - **Inline math** (in lists) should be added with `\$$ math $$`
 
 ```markdown
-# Block math, keep all blank lines
+<!-- Block math, keep all blank lines -->
 
 $$
 LaTeX_math_expression
 $$
 
-# Inline math in lines, NO blank lines
+<!-- Inline math in lines, NO blank lines -->
+
 "Lorem ipsum dolor sit amet, $$ LaTeX_math_expression $$ consectetur adipiscing elit."
 
-# Inline math in lists, escape the first $
+<!-- Inline math in lists, escape the first `$` -->
+
 1. \$$ LaTeX_math_expression $$
 2. \$$ LaTeX_math_expression $$
-- \$$ LaTeX_math_expression $$
+3. \$$ LaTeX_math_expression $$
 ```
-
-The solutions above have only been tested with [jekyll-theme-chirpy](https://github.com/cotes2020/jekyll-theme-chirpy). 
-{: .prompt-info }
 
 ## Mermaid
 

--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -107,9 +107,34 @@ math: true
 ---
 ```
 
+After enabling the mathematical feature, you can add math equations with the following syntax: 
+
+- **Block math** should be added with `$$ math $$` *with* **mandatory** blank lines before and after `$$`
+- **Inline math** (in lines) should be added with `$$ math $$` *without* any blank line before or after `$$`
+- **Inline math** (in lists) should be added with `\$$ math $$`
+
+```markdown
+# Block math, keep all blank lines
+
+$$
+LaTeX_math_expression
+$$
+
+# Inline math in lines, NO blank lines
+"Lorem ipsum dolor sit amet, $$ LaTeX_math_expression $$ consectetur adipiscing elit."
+
+# Inline math in lists, escape the first $
+1. \$$ LaTeX_math_expression $$
+2. \$$ LaTeX_math_expression $$
+- \$$ LaTeX_math_expression $$
+```
+
+> Kramdown, the default markdown engine of Jekyll and GitHub, might have some bugs with parsing math blocks with its [default syntax](https://kramdown.gettalong.org/syntax.html#math-blocks). Experiments to reproduce the bug can be found [here](https://zhengyuan-public.github.io/posts/PersonalBlogWithJekyll/#latex-math-equations-in-jekyll). The solutions above have only been tested with [jekyll-theme-chirpy](https://github.com/cotes2020/jekyll-theme-chirpy). 
+{: .prompt-info }
+
 ## Mermaid
 
-[**Mermaid**](https://github.com/mermaid-js/mermaid) is a great diagrams generation tool. To enable it on your post, add the following to the YAML block:
+[**Mermaid**](https://github.com/mermaid-js/mermaid) is a great diagram generation tool. To enable it on your post, add the following to the YAML block:
 
 ```yaml
 ---
@@ -123,7 +148,7 @@ Then you can use it like other markdown languages: surround the graph code with 
 
 ### Caption
 
-Add italics to the next line of an image，then it will become the caption and appear at the bottom of the image:
+Add italics to the next line of an image, then it will become the caption and appear at the bottom of the image:
 
 ```markdown
 ![img-description](/path/to/image)


### PR DESCRIPTION

## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change
-->
1. Add docs for block math and inline math
2. Change a grammar mistake at line 137, the single form should be used
3. Change the comma at line 151 from Chinese to English for consistency
## Additional context
<!-- e.g. Fixes #(issue) -->
Some URLs related to the solutions added in doc.

- Understanding the origin of the problem from a MathJax issue [here](https://github.com/mathjax/MathJax/issues/3103#issuecomment-1750121053)
- [Docs](https://kramdown.gettalong.org/syntax.html#math-blocks) specifying the math block syntax used by kramdown
- [Experiments](https://zhengyuan-public.github.io/posts/PersonalBlogWithJekyll/#latex-math-equations-in-jekyll) that showed the default kramdown syntax is not working as expected and solutions that work with [jekyll-theme-chirpy](https://github.com/cotes2020/jekyll-theme-chirpy)

