### PR TITLE
fix(home): crop the preview image that doesn't match 1.91:1

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -309,7 +309,6 @@ sup {
 .preview-img {
   aspect-ratio: 40 / 21;
   width: 100%;
-  height: 100%;
   overflow: hidden;
 
   @extend %rounded;
@@ -324,6 +323,10 @@ sup {
     object-fit: cover;
 
     @extend %rounded;
+
+    @at-root #post-list & {
+      width: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Additional context

Fixes #1312 
