### PR TITLE
fix: resume lazy loading for Twitch videos

### DIFF
--- a/_includes/embed/twitch.html
+++ b/_includes/embed/twitch.html
@@ -1,5 +1,6 @@
 <iframe
   class="embed-video twitch"
+  loading="lazy"
   src="https://player.twitch.tv/?video={{ include.id }}&parent={{ site.url | split: '://' | last | remove: '/' }}"
   frameborder="0"
   allowfullscreen="true"


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

The property of lazy load is missing in #1267

