### PR TITLE
Add Mastodon sharing link

### DIFF
--- a/_data/share.yml
+++ b/_data/share.yml
@@ -26,13 +26,13 @@ platforms:
   #
   # - type: Mastodon
   #   icon: "fa-brands fa-mastodon"
-  #   link: |
-  #     [
-  #       {&quot;label&quot;:&quot;Mastodon.Social&quot;,&quot;link&quot;:&quot;https://mastodon.social/&quot;},
-  #       {&quot;label&quot;:&quot;Mastodon.Online&quot;,&quot;link&quot;:&quot;https://mastodon.online/&quot;},
-  #       {&quot;label&quot;:&quot;fosstodon.org&quot;,&quot;link&quot;:&quot;https://fosstodon.org/&quot;},
-  #       {&quot;label&quot;:&quot;photog.social&quot;,&quot;link&quot;:&quot;https://photog.social/&quot;}]
-  #
-  # The Mastodon sharing uses https://www.npmjs.com/package/@justinribeiro/share-to-mastodon, which doesn't
-  # seem to respect the single or double quotes if you specify it here. So, you'll need to use the `&quot;`
-  # HTML entity instead.  These are the default instances listed in the package.
+  #   # See: https://github.com/justinribeiro/share-to-mastodon#properties
+  #   instances:
+  #     - label: mastodon.social
+  #       link: "https://mastodon.social/"
+  #     - label: mastodon.online
+  #       link: "https://mastodon.online/"
+  #     - label: fosstodon.org
+  #       link: "https://fosstodon.org/"
+  #     - label: photog.social
+  #       link: "https://photog.social/"

--- a/_data/share.yml
+++ b/_data/share.yml
@@ -23,3 +23,16 @@ platforms:
   # - type: Weibo
   #   icon: "fab fa-weibo"
   #   link: "http://service.weibo.com/share/share.php?title=TITLE&url=URL"
+  #
+  # - type: Mastodon
+  #   icon: "fa-brands fa-mastodon"
+  #   link: |
+  #     [
+  #       {&quot;label&quot;:&quot;Mastodon.Social&quot;,&quot;link&quot;:&quot;https://mastodon.social/&quot;},
+  #       {&quot;label&quot;:&quot;Mastodon.Online&quot;,&quot;link&quot;:&quot;https://mastodon.online/&quot;},
+  #       {&quot;label&quot;:&quot;fosstodon.org&quot;,&quot;link&quot;:&quot;https://fosstodon.org/&quot;},
+  #       {&quot;label&quot;:&quot;photog.social&quot;,&quot;link&quot;:&quot;https://photog.social/&quot;}]
+  #
+  # The Mastodon sharing uses https://www.npmjs.com/package/@justinribeiro/share-to-mastodon, which doesn't
+  # seem to respect the single or double quotes if you specify it here. So, you'll need to use the `&quot;`
+  # HTML entity instead.  These are the default instances listed in the package.

--- a/_includes/post-sharing.html
+++ b/_includes/post-sharing.html
@@ -1,64 +1,51 @@
 <!-- Post sharing snippet -->
 
 <div class="share-wrapper d-flex align-items-center">
-  <span class="share-label text-muted me-1">{{ site.data.locales[include.lang].post.share }}</span>
+  <span class="share-label text-muted">{{ site.data.locales[include.lang].post.share }}</span>
   <span class="share-icons">
     {% capture title %}{{ page.title }} - {{ site.title }}{% endcapture %}
     {% assign title = title | uri_escape %}
     {% assign url = page.url | absolute_url | url_encode %}
 
-    {% for share in site.data.share.platforms %}{% unless share.type == 'Mastodon' %}
-    {% assign link = share.link | replace: 'TITLE', title | replace: 'URL', url %}
-    <a
-      href="{{ link }}"
-      data-bs-toggle="tooltip"
-      data-bs-placement="top"
-      title="{{ share.type }}"
-      target="_blank"
-      rel="noopener"
-      aria-label="{{ share.type }}"
-    >
-      <i class="fa-fw {{ share.icon }}"></i>
-    </a>
-  {% endunless %}
-  {% if share.type == 'Mastodon' %}
-    <button
-        id="share-to-mastodon"
-        aria-label="Mastodon"
-        class="btn small"
+    {% for share in site.data.share.platforms -%}
+      {% if share.type == 'Mastodon' %}
+        <script defer type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/share-to-mastodon/+esm"></script>
+        <button
+          class="btn text-start"
+          data-bs-toggle="tooltip"
+          data-bs-placement="top"
+          title="{{ share.type }}"
+          aria-label="{{ share.type }}"
+        >
+          <share-to-mastodon
+            class="share-mastodon"
+            message="{{ title }}"
+            url="{{ url }}"
+            {%- if share.instances -%}
+              customInstanceList="{{ share.instances | jsonify | xml_escape }}"
+            {%- endif %}
+          >
+            <i class="{{ share.icon }}"></i>
+          </share-to-mastodon>
+        </button>
+
+        {% continue %}
+      {% endif %}
+
+      {% assign link = share.link | replace: 'TITLE', title | replace: 'URL', url %}
+
+      <a
+        href="{{ link }}"
         data-bs-toggle="tooltip"
         data-bs-placement="top"
-        title="Mastodon"
+        title="{{ share.type }}"
+        target="_blank"
+        rel="noopener"
+        aria-label="{{ share.type }}"
       >
-        <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/share-to-mastodon/+esm"></script>
-        <share-to-mastodon
-          message="{{ page.title }}"
-          url="{{ page.url | absolute_url }}"
-          style="
-            --wc-stm-color: var(--text-color);
-            --wc-stm-link-color-initial: var(--btn-share-color);
-            --wc-stm-dialog-background-color: var(--sidebar-bg);
-            --wc-stm-dialog-border-color: var(--sidebar-border-color);
-            --wc-stm-font-family: 'Source Sans Pro','Microsoft Yahei',sans-serif;
-            --wc-stm-font-color: var(--text-color);
-            --wc-stm-link-text-decoration: none;
-            --wc-stm-form-button-background-color: var(--main-bg);
-            --wc-stm-form-button-background-color-hover: var(--sidebar-hover-bg);
-            --wc-stm-form-input-border: var(--sidebar-border-color);
-            --wc-stm-link-color-active: var(--btn-share-color);
-            --wc-stm-link-color-initial: var(--btn-share-color);
-            --wc-stm-link-color-visited: var(--btn-share-color);
-            --wc-stm-form-submit-background-color: var(--sidebar-btn-bg);
-            --wc-stm-form-cancel-background-color: var(--sidebar-btn-bg);
-            --wc-stm-form-submit-color: var(--sidebar-btn-color);
-            --wc-stm-form-cancel-color: var(--sidebar-btn-color);"
-          customInstanceList="{{ share.link }}"
-        >
-          <i class="{{ share.icon }}"></i>
-        </share-to-mastodon>
-      </button>
-  {% endif %}
-  {% endfor %}
+        <i class="fa-fw {{ share.icon }}"></i>
+      </a>
+    {% endfor %}
 
     <button
       id="copy-link"
@@ -69,7 +56,7 @@
       title="{{ site.data.locales[include.lang].post.button.share_link.title }}"
       data-title-succeed="{{ site.data.locales[include.lang].post.button.share_link.succeed }}"
     >
-      <i class="fa-fw fas fa-link pe-none"></i>
+      <i class="fa-fw fas fa-link pe-none fs-6"></i>
     </button>
   </span>
 </div>

--- a/_includes/post-sharing.html
+++ b/_includes/post-sharing.html
@@ -7,20 +7,58 @@
     {% assign title = title | uri_escape %}
     {% assign url = page.url | absolute_url | url_encode %}
 
-    {% for share in site.data.share.platforms %}
-      {% assign link = share.link | replace: 'TITLE', title | replace: 'URL', url %}
-      <a
-        href="{{ link }}"
+    {% for share in site.data.share.platforms %}{% unless share.type == 'Mastodon' %}
+    {% assign link = share.link | replace: 'TITLE', title | replace: 'URL', url %}
+    <a
+      href="{{ link }}"
+      data-bs-toggle="tooltip"
+      data-bs-placement="top"
+      title="{{ share.type }}"
+      target="_blank"
+      rel="noopener"
+      aria-label="{{ share.type }}"
+    >
+      <i class="fa-fw {{ share.icon }}"></i>
+    </a>
+  {% endunless %}
+  {% if share.type == 'Mastodon' %}
+    <button
+        id="share-to-mastodon"
+        aria-label="Mastodon"
+        class="btn small"
         data-bs-toggle="tooltip"
         data-bs-placement="top"
-        title="{{ share.type }}"
-        target="_blank"
-        rel="noopener"
-        aria-label="{{ share.type }}"
+        title="Mastodon"
       >
-        <i class="fa-fw {{ share.icon }}"></i>
-      </a>
-    {% endfor %}
+        <script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/share-to-mastodon/+esm"></script>
+        <share-to-mastodon
+          message="{{ page.title }}"
+          url="{{ page.url | absolute_url }}"
+          style="
+            --wc-stm-color: var(--text-color);
+            --wc-stm-link-color-initial: var(--btn-share-color);
+            --wc-stm-dialog-background-color: var(--sidebar-bg);
+            --wc-stm-dialog-border-color: var(--sidebar-border-color);
+            --wc-stm-font-family: 'Source Sans Pro','Microsoft Yahei',sans-serif;
+            --wc-stm-font-color: var(--text-color);
+            --wc-stm-link-text-decoration: none;
+            --wc-stm-form-button-background-color: var(--main-bg);
+            --wc-stm-form-button-background-color-hover: var(--sidebar-hover-bg);
+            --wc-stm-form-input-border: var(--sidebar-border-color);
+            --wc-stm-link-color-active: var(--btn-share-color);
+            --wc-stm-link-color-initial: var(--btn-share-color);
+            --wc-stm-link-color-visited: var(--btn-share-color);
+            --wc-stm-form-submit-background-color: var(--sidebar-btn-bg);
+            --wc-stm-form-cancel-background-color: var(--sidebar-btn-bg);
+            --wc-stm-form-submit-color: var(--sidebar-btn-color);
+            --wc-stm-form-cancel-color: var(--sidebar-btn-color);"
+          customInstanceList="{{ share.link }}"
+        >
+          <i class="{{ share.icon }}"></i>
+        </share-to-mastodon>
+      </button>
+  {% endif %}
+  {% endfor %}
 
     <button
       id="copy-link"

--- a/_sass/colors/typography-light.scss
+++ b/_sass/colors/typography-light.scss
@@ -63,7 +63,8 @@
 
   /* Posts */
   --toc-highlight: #0550ae;
-  --btn-share-hover-color: var(--link-color);
+  --btn-share-color: gray;
+  --btn-share-hover-color: #0d6efd;
   --card-bg: white;
   --card-hovor-bg: #e2e2e2;
   --card-shadow: rgb(104, 104, 104, 0.05) 0 2px 6px 0,

--- a/_sass/layout/post.scss
+++ b/_sass/layout/post.scss
@@ -2,14 +2,6 @@
   Post-specific style
 */
 
-@mixin btn-sharing-color($light-color, $important: false) {
-  @if $important {
-    color: var(--btn-share-color, $light-color) !important;
-  } @else {
-    color: var(--btn-share-color, $light-color);
-  }
-}
-
 %btn-post-nav {
   width: 50%;
   position: relative;
@@ -72,11 +64,23 @@ h1 + .post-meta {
     -ms-user-select: none;
     user-select: none;
 
+    %icon-size {
+      font-size: 1.125rem;
+    }
+
     .share-icons {
-      font-size: 1.2rem;
+      display: flex;
+
+      i {
+        color: var(--btn-share-color);
+
+        @extend %icon-size;
+      }
 
       > * {
-        margin-left: 0.25rem;
+        @extend %icon-size;
+
+        margin-left: 0.5rem;
 
         &:hover {
           i {
@@ -87,41 +91,26 @@ h1 + .post-meta {
 
       button {
         position: relative;
-        bottom: 2px;
+        bottom: 1px;
         padding: 0;
 
         @extend %cursor-pointer;
       }
-
-      a :hover {
-        text-decoration: none;
-      }
-
-      .fa-square-x-twitter {
-        @include btn-sharing-color(black);
-      }
-
-      .fa-facebook-square {
-        @include btn-sharing-color(rgb(66, 95, 156));
-      }
-
-      .fa-telegram {
-        @include btn-sharing-color(rgb(39, 159, 217));
-      }
-
-      .fa-linkedin {
-        @include btn-sharing-color(rgb(0, 119, 181));
-      }
-
-      .fa-weibo {
-        @include btn-sharing-color(rgb(229, 20, 43));
-      }
     } /* .share-icons */
-
-    .fas.fa-link {
-      @include btn-sharing-color(rgb(171, 171, 171));
-    }
   } /* .share-wrapper */
+}
+
+.share-mastodon {
+  /* See: https://github.com/justinribeiro/share-to-mastodon#properties */
+  --wc-stm-font-family: $font-family-base;
+  --wc-stm-dialog-background-color: var(--card-bg);
+  --wc-stm-form-button-border: 1px solid var(--btn-border-color);
+  --wc-stm-form-submit-background-color: var(--sidebar-btn-bg);
+  --wc-stm-form-cancel-background-color: var(--sidebar-btn-bg);
+  --wc-stm-form-button-background-color-hover: #007bff;
+  --wc-stm-form-button-color-hover: white;
+
+  font-size: 1rem;
 }
 
 .post-tags {


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->

This PR adds a "share to Mastodon" button as a link sharing option using @justinribeiro's share-to-mastodon package ([GitHub](https://github.com/justinribeiro/share-to-mastodon) and [NPM](https://www.npmjs.com/package/@justinribeiro/share-to-mastodon)).  I made a best guess at the correct CSS color variables to use and it seems to look alright.

- Example usage was added to `_data/share.yml`
- Liquid tags reworked slightly in `_includes/post-sharing.html` to only add the button if it was selected as an option

## Additional context

Discussion of proposed change - <https://github.com/cotes2020/jekyll-theme-chirpy/discussions/1324>
Example site w/ change in place - <https://some-natalie.dev/>
