### PR TITLE
Fix icon for info prompt

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -110,7 +110,7 @@ blockquote {
   }
 
   @include prompt('tip', '\f0eb', 'regular');
-  @include prompt('info', '\f06a');
+  @include prompt('info', '\f05a');
   @include prompt('warning', '\f06a');
   @include prompt('danger', '\f071');
 }


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
The `info` prompt used the f06a icon (exclamation point) instead of the f05a (information sign)

Before:
![image](https://github.com/cotes2020/jekyll-theme-chirpy/assets/4533568/1814f795-9c9c-4a46-bd52-d33ec1a04057)


After:
![image](https://github.com/cotes2020/jekyll-theme-chirpy/assets/4533568/bc8f3ea7-2af0-41b8-bad9-e74a2d5e41b5)

