### PR TITLE
fix: url-less authors should not have empty links

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -61,7 +61,11 @@ tail_includes:
           <em>
             {% if authors %}
               {% for author in authors %}
-                <a href="{{ site.data.authors[author].url }}">{{ site.data.authors[author].name }}</a>
+                {% if site.data.authors[author].url -%}
+                  <a href="{{ site.data.authors[author].url }}">{{ site.data.authors[author].name }}</a>
+                {%- else -%}
+                  {{ site.data.authors[author].name }}
+                {%- endif %}
                 {% unless forloop.last %}{{ '</em>, <em>' }}{% endunless %}
               {% endfor %}
             {% else %}


### PR DESCRIPTION

## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->
The url field from `authors.yml` is optional, so no link should be build when the url is empty or not defined. Previously, an empty `HREF` was generated, which is flagged as an error by html-proofer.

This change carefully controls white-space, so existing sites with defined `author.url` will be identical.

## Additional context
<!-- e.g. Fixes #(issue) -->
Fixes #1403