### PR TITLE
build(deps): specify the minor version number of ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        ruby: ["3.0", "3.1", "3.2"]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,7 +32,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
       - name: Setup Node

--- a/.github/workflows/pages-deploy.yml.hook
+++ b/.github/workflows/pages-deploy.yml.hook
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3
+          ruby-version: 3.2
           bundler-cache: true
 
       - name: Build site


### PR DESCRIPTION


## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Improvement (refactoring and improving code)


## Description

Jekyll's dependency [`protobuf`](https://github.com/protocolbuffers/protobuf)  is not yet compatible with Ruby 3.3. Until it releases a new version, limit the Chirpy project CI/CD to ruby versions 3.0 to 3.2. 

## Additional context

Resolves #1429
