### PR TITLE
Fix htmlproofer path in ci

### DIFF
--- a/.github/workflows/pages-deploy.yml.hook
+++ b/.github/workflows/pages-deploy.yml.hook
@@ -52,7 +52,7 @@ jobs:
 
       - name: Test site
         run: |
-          bundle exec htmlproofer _site \
+          bundle exec htmlproofer _site/blog \
             \-\-disable-external=true \
             \-\-ignore-urls "/^http:\/\/127.0.0.1/,/^http:\/\/0.0.0.0/,/^http:\/\/localhost/"
 


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->
I used this repo as a template and the github actions failed because I guess htmlproofer was looking at the wrong directory. Once I changed `_site` to `_site/blog` it fixed the issue.
Here is the failing action: https://github.com/karlmolina/blog/actions/runs/7366373473/job/20048587742#step:6:475
And here is the fixed action after my change: https://github.com/karlmolina/blog/actions/runs/7366433467/job/20048693278

If this is supposed to work this way for some reason let me know and you can close the pr.

## Additional context
<!-- e.g. Fixes #(issue) -->
