### PR TITLE
fix: image float breaks quotes and prompts

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -85,6 +85,7 @@ blockquote {
   border-left: 5px solid var(--blockquote-border-color);
   padding-left: 1rem;
   color: var(--blockquote-text-color);
+  display: flex;
 
   &[class^='prompt-'] {
     border-left: 0;
@@ -641,12 +642,12 @@ main {
 
 .left {
   float: left;
-  margin: 0.75rem 1rem 1rem 0 !important;
+  margin: 0.75rem 1rem 1rem 0;
 }
 
 .right {
   float: right;
-  margin: 0.75rem 0 1rem 1rem !important;
+  margin: 0.75rem 0 1rem 1rem;
 }
 
 /* --- Overriding --- */


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Fix image left / right position breaking the structure of its subsequent prompts / quote-blocks. But for technical reasons, do not change the problem of overlapping edges of existing float images and list marker.

If for some special reason it is necessary to use a list after a float image, then we can add a Bootstrap class to the image to avoid the overlapping list marker. For instance, add  `pe-3` to the left-float image:

```markdown
![alt](/path/to/image){: .left .pe-3 }

- Entry a
- Entry b
- Entry c
```

## Additional context
<!-- e.g. Fixes #(issue) -->

- Fixes #1441
