### PR TITLE
fix: `og:image` URL  is incorrect

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,7 +26,7 @@
       {%- capture old_url -%}{{ src | absolute_url }}{%- endcapture -%}
       {%- capture new_url -%}{{ img_url }}{%- endcapture -%}
 
-      {% assign seo_tags = seo_tags | replace: old, new %}
+      {% assign seo_tags = seo_tags | replace: old_url, new_url %}
     {% endunless %}
 
   {% elsif site.social_preview_image %}

--- a/_includes/img-url.html
+++ b/_includes/img-url.html
@@ -12,13 +12,21 @@
 {% assign url = include.src %}
 
 {%- if url -%}
-  {%- comment -%} CND URL {%- endcomment -%}
-  {% assign prefix = site.img_cdn | default: '' | relative_url %}
+  {% unless url contains ':' %}
+    {%- comment -%} CND URL {%- endcomment -%}
+    {% assign prefix = site.img_cdn | default: '' | relative_url %}
 
-  {%- comment -%} Add page image path prefix {%- endcomment -%}
-  {% assign url = include.img_path | default: '' | append: '/' | append: url %}
+    {%- comment -%} Add page image path prefix {%- endcomment -%}
+    {% assign url = include.img_path | default: '' | append: '/' | append: url %}
 
-  {% assign url = prefix | append: '/' | append: url | replace: '///', '/' | replace: '//', '/' | replace: ':', ':/' %}
+    {% assign url = prefix
+      | append: '/'
+      | append: url
+      | replace: '///', '/'
+      | replace: '//', '/'
+      | replace: ':', ':/'
+    %}
+  {% endunless %}
 {%- endif -%}
 
 {{- url -}}


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

- `_includes/head.html` -  The editor's _Find and Replace_ changed the names of two variables incorrectly
- `_includes/img-url.html` - `site.img_cdn` CORS judgment condition is missing

## Additional context
<!-- e.g. Fixes #(issue) -->

- Fixes #1467 
- Introduced by #1463 
