### PR TITLE
perf: allow no social links to be configured

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,9 +8,15 @@
   "
 >
   <p>
-    {{ '©' }}
+    {{- '©' }}
     <time>{{ 'now' | date: '%Y' }}</time>
-    <a href="{{ site.social.links[0] }}">{{ site.social.name }}</a>.
+
+    {% if site.social.links %}
+      <a href="{{ site.social.links[0] }}">{{ site.social.name }}</a>.
+    {% else %}
+      <em class="fst-normal">{{ site.social.name }}</em>.
+    {% endif %}
+
     {% if site.data.locales[include.lang].copyright.brief %}
       <span
         data-bs-toggle="tooltip"

--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -144,6 +144,10 @@ footer {
     }
   }
 
+  em {
+    @extend %text-highlight;
+  }
+
   p {
     text-align: center;
     margin-bottom: 0;


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Improvement (refactoring and improving code)


## Description

If `site.social.links` is empty, invalid blank links will be generated in the HTML page.

## Additional context

- Fixes #1493 
