### PR TITLE
fix: missing "/" at the end of URLs for categories and tags in breadcrumb

### DIFF
--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -17,7 +17,7 @@
           {% if forloop.first %}
             <span>
               <a href="{{ '/' | relative_url }}">
-                {{ site.data.locales[include.lang].tabs.home | capitalize }}
+                {{- site.data.locales[include.lang].tabs.home | capitalize -}}
               </a>
             </span>
 
@@ -30,8 +30,8 @@
 
           {% elsif page.layout == 'category' or page.layout == 'tag' %}
             <span>
-              <a href="{{ item | relative_url }}">
-                {{ site.data.locales[include.lang].tabs[item] | default: page.title }}
+              <a href="{{ item | append: '/' | relative_url }}">
+                {{- site.data.locales[include.lang].tabs[item] | default: page.title -}}
               </a>
             </span>
           {% endif %}


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

In tablet/desktop view (screen width >= 850px), a slash `/` is missing from the end of the `tags` and `categories` link in the breadcrumbs.

For example:

<p>
<img width="569" alt="Screen Shot 2024-01-19 at 05 57 53" src="https://github.com/cotes2020/jekyll-theme-chirpy/assets/11371340/bf771bdc-d952-462e-88b3-f7a3cc98d43d">
</p>

Visitors will not notice any problem when the network is working properly, because the browser will correct the URL automatically.

However, this causes PWA to fail to cache the pages `tags.html` and `categories.html`, so these two pages are repeatedly fetched from the network, and when the network is disconnected PWA ServiceWorker returns no cached content.

## Additional context
<!-- e.g. Fixes #(issue) -->
N/A
