### PR TITLE
down minimum header size for making toc

### DIFF
--- a/_javascript/modules/components/toc.js
+++ b/_javascript/modules/components/toc.js
@@ -1,5 +1,5 @@
 export function toc() {
-  if (document.querySelector('main h2')) {
+  if (document.querySelector('main h2, h3')) {
     // see: https://github.com/tscanlin/tocbot#usage
     tocbot.init({
       tocSelector: '#toc',


### PR DESCRIPTION
## Type of change
- [x] Improvement (refactoring and improving code)

## Description
Currently, the TOC only functions with the presence of h2 tags. However, tocbot's default setting is designed to work with h2, h3, and h4 tags. Even if h4 can be hidden in the TOC, I thought it might be better to generate the TOC with h3 tags regardless of whether h2 tags are present or not. (Users might want to start with h3 tags.) Therefore, I've modified the initialization conditions for tocbot to also check for the presence of h3 tags.

## Additional context


