### PR TITLE
Add analytics support for GoatCounter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - Atom Feeds
 - PWA
 - Google Analytics
+- GoatCounter
 - SEO & Performance Optimization
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@
 - Built-in Search
 - Atom Feeds
 - PWA
-- Google Analytics
-- GoatCounter
+- Google Analytics / GoatCounter
 - SEO & Performance Optimization
 
 ## Documentation

--- a/_config.yml
+++ b/_config.yml
@@ -52,6 +52,9 @@ google_site_verification: # fill in to your verification string
 google_analytics:
   id: # fill in your Google Analytics ID
 
+goatcounter:
+  id: # fill in your Goatcounter ID
+
 # Prefer color scheme setting.
 #
 # Note: Keep empty will follow the system prefer color by default,

--- a/_includes/goatcounter.html
+++ b/_includes/goatcounter.html
@@ -1,6 +1,3 @@
-<!--
-  The GoatCounter snippet
--->
 <!-- GoatCounter -->
 
 <script data-goatcounter="https://{{ site.goatcounter.id }}.goatcounter.com/count"

--- a/_includes/goatcounter.html
+++ b/_includes/goatcounter.html
@@ -4,5 +4,5 @@
 <!-- GoatCounter -->
 
 <script data-goatcounter="https://{{ site.goatcounter.id }}.goatcounter.com/count"
-        async src="//gc.zgo.at/count.js"></script>
+        async src="https://gc.zgo.at/count.js"></script>
 

--- a/_includes/goatcounter.html
+++ b/_includes/goatcounter.html
@@ -1,0 +1,8 @@
+<!--
+  The GoatCounter snippet
+-->
+<!-- GoatCounter -->
+
+<script data-goatcounter="https://{{ site.goatcounter.id }}.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
+

--- a/_includes/goatcounter.html
+++ b/_includes/goatcounter.html
@@ -5,5 +5,4 @@
   async
   src="https://gc.zgo.at/count.js"
 ></script>
-        async src="https://gc.zgo.at/count.js"></script>
 

--- a/_includes/goatcounter.html
+++ b/_includes/goatcounter.html
@@ -1,5 +1,9 @@
 <!-- GoatCounter -->
 
-<script data-goatcounter="https://{{ site.goatcounter.id }}.goatcounter.com/count"
+<script
+  data-goatcounter="https://{{ site.goatcounter.id }}.goatcounter.com/count"
+  async
+  src="https://gc.zgo.at/count.js"
+></script>
         async src="https://gc.zgo.at/count.js"></script>
 

--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -105,4 +105,9 @@
   {% if site.google_analytics.id != empty and site.google_analytics.id %}
     {% include google-analytics.html %}
   {% endif %}
+
+  <!-- GoatCounter -->
+  {% if site.goatcounter.id != empty and site.goatcounter.id %}
+    {% include goatcounter.html %}
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] New feature (non-breaking change which adds functionality)

## Description
This PR adds support for a privacy-friendly alternative to Google Analytics called GoatCounter (https://www.goatcounter.com). The integration is relatively simple so it should be a low-risk addition. Documentation can be found here: https://www.goatcounter.com/help/start

Additionally I've tested this implementation in my own blog and it works fine. If you have any questions or remarks I will gladly address them of course.
