### PR TITLE
fix: correct the generation of relative resource paths

### DIFF
--- a/_includes/img-url.html
+++ b/_includes/img-url.html
@@ -29,9 +29,9 @@
     %}
 
     {% if include.absolute %}
-      {% assign url = url | absolute_url %}
+      {% assign url = site.url | append: site.base_url | append: url %}
     {% else %}
-      {% assign url = url | relative_url %}
+      {% assign url = site.base_url | append: url %}
     {% endif %}
   {% endunless %}
 {%- endif -%}


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

The filter (`relative_url` and `absolute_url`) that comes with Jekyll removes the `.` from the relative path. So there are occasions when it is not appropriate to use them.

## Additional context
<!-- e.g. Fixes #(issue) -->
- Fixes #1541
