### PR TITLE
feat: add support for embed video files

### DIFF
--- a/_includes/embed/bilibili.html
+++ b/_includes/embed/bilibili.html
@@ -1,10 +1,9 @@
 <iframe
-  class="embed-video bilibili"
+  class="embed-video"
   loading="lazy"
   src="https://player.bilibili.com/player.html?bvid={{ include.id }}"
   scrolling="no"
-  border="0"
-  frameborder="no"
+  frameborder="0"
   framespacing="0"
   allowfullscreen="true"
 ></iframe>

--- a/_includes/embed/video.html
+++ b/_includes/embed/video.html
@@ -1,0 +1,38 @@
+{% assign video_url = include.src %}
+{% assign poster_url = include.poster %}
+
+{% unless video_url contains '://' %}
+  {%- capture video_url -%}
+    {% include img-url.html src=video_url img_path=page.img_path %}
+  {%- endcapture -%}
+{% endunless %}
+
+{% if poster_url %}
+  {% unless poster_url contains '://' %}
+    {%- capture poster_url -%}
+      {% include img-url.html src=poster_url img_path=page.img_path %}
+    {%- endcapture -%}
+  {% endunless %}
+  {% assign poster = 'poster="' | append: poster_url | append: '"' %}
+{% endif %}
+
+{% assign attributes = 'controls' %}
+
+{% if include.autoplay %}
+  {% assign attributes = attributes | append: ' ' | append: 'autoplay' %}
+{% endif %}
+
+{% if include.loop %}
+  {% assign attributes = attributes | append: ' ' | append: 'loop' %}
+{% endif %}
+
+{% if include.muted %}
+  {% assign attributes = attributes | append: ' ' | append: 'muted' %}
+{% endif %}
+
+<p>
+  <video class="embed-video file" src="{{ video_url }}" {{ poster }} {{ attributes }}>
+    Your browser doesn't support HTML video. Here is a <a href="{{ url }}">link to the video</a> instead.
+  </video>
+  <em>{{ include.title }}</em>
+</p>

--- a/_includes/embed/youtube.html
+++ b/_includes/embed/youtube.html
@@ -1,5 +1,5 @@
 <iframe
-  class="embed-video youtube"
+  class="embed-video"
   loading="lazy"
   src="https://www.youtube.com/embed/{{ include.id }}"
   title="YouTube video player"

--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -427,6 +427,8 @@ Or adding `render_with_liquid: false` (Requires Jekyll 4.0 or higher) to the pos
 
 ## Videos
 
+### Video Sharing Platform
+
 You can embed a video with the following syntax:
 
 ```liquid
@@ -442,6 +444,31 @@ The following table shows how to get the two parameters we need in a given video
 | [https://www.**youtube**.com/watch?v=**H-B46URT4mg**](https://www.youtube.com/watch?v=H-B46URT4mg) | `youtube`  | `H-B46URT4mg`  |
 | [https://www.**twitch**.tv/videos/**1634779211**](https://www.twitch.tv/videos/1634779211)         | `twitch`   | `1634779211`   |
 | [https://www.**bilibili**.com/video/**BV1Q44y1B7Wf**](https://www.bilibili.com/video/BV1Q44y1B7Wf) | `bilibili` | `BV1Q44y1B7Wf` |
+
+### Video File
+
+If you want to embed a video file directly, use the following syntax:
+
+```liquid
+{% include embed/video.html src='{URL}' %}
+```
+
+Where `URL` is an URL to a video file e.g. `/assets/img/sample/video.mp4`.
+
+You can also specify additional attributes for the embedded video file. Here is a full list of attributes allowed.
+
+- `poster='/path/to/poster.png'` - poster image for a video that is shown while video is downloading
+- `title='Text'` - title for a video that appears below the video and looks same as for images
+- `autoplay=true` - video automatically begins to play back as soon as it can
+- `loop=true` - automatically seek back to the start upon reaching the end of the video
+- `muted=true` - audio will be initially silenced
+
+Consider an example utilizing all of the above:
+
+```liquid
+{% include embed/video.html src='video.mp4' poster='poster.png' title='Demo video'
+   autoplay=true loop=true muted=true %}
+```
 
 ## Learn More
 

--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -550,17 +550,25 @@ main {
   width: 100%;
   height: 100%;
   margin-bottom: 1rem;
+  aspect-ratio: 16 / 9;
 
   @extend %rounded;
-
-  &.youtube,
-  &.bilibili {
-    aspect-ratio: 16 / 9;
-  }
 
   &.twitch {
     aspect-ratio: 310 / 189;
   }
+
+  &.file {
+    display: block;
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 100%;
+    margin: auto;
+    margin-bottom: 0;
+  }
+
+  @extend %img-caption;
 }
 
 /* --- buttons --- */


### PR DESCRIPTION
## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Description
I want to embed a video file hosted on my own blog, CDN, or publicly available without a video platform using the HTML 5 `<video>` element.

## Implementation
Here are examples on how you can include video file with respect to `img_cdn` and `img_path` variables.

```html
{% include embed/video.html
src='https://upload.wikimedia.org/wikipedia/commons/transcoded/a/a7/How_to_make_video.webm/How_to_make_video.webm.720p.vp9.webm'
autoplay=true
loop=true
muted=true
title='How to make video' %}

{% include embed/video.html src='demo.mp4' autoplay=true loop=true title='Demo video' %}
```

Arguments:
- `src` - required, path to a file
- `poster='/path/to/poster.png'` - optional, poster image for a video that is shown while video is downloading
- `title='Text'` - optional, title for a video that appears below the video and looks same as for images
- `autoplay=true` - optional, video automatically begins to play back as soon as it can
- `loop=true` - optional, automatically seek back to the start upon reaching the end of the video
- `muted=true` - optional, audio will be initially silenced

## Demo
![image](https://github.com/cotes2020/jekyll-theme-chirpy/assets/10548881/5ba5d6b6-8df7-4fa4-98ad-9f21ae2bb723)
Note: 2nd and 3rd videos are added using new functionality.