### PR TITLE
build(deps-dev): remove deprecated library and add new one the npm group with 1 update

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
+    "@babel/plugin-transform-class-properties": "^7.23.3",
     "@babel/preset-env": "^7.23.9",
     "@commitlint/cli": "^18.6.1",
     "@commitlint/config-conventional": "^18.6.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,7 @@ function build(filename) {
       babel({
         babelHelpers: 'bundled',
         presets: ['@babel/env'],
-        plugins: ['@babel/plugin-proposal-class-properties']
+        plugins: ['@babel/plugin-transform-class-properties']
       }),
       license({
         banner: {


### PR DESCRIPTION
## Description
- @babel/plugin-proposal-class-properties was deprecated
  - https://www.npmjs.com/package/@babel/plugin-proposal-class-properties
- update to use @babel/plugin-transform-class-properties instead