### PR TITLE
feat: change site verification settings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,7 +44,14 @@ social:
     # - https://www.facebook.com/username
     # - https://www.linkedin.com/in/username
 
-google_site_verification: # fill in to your verification string
+# Site Verification Settings
+webmaster_verifications:
+  google: # fill in your Google verification code
+  bing: # fill in your Bing verification code
+  alexa: # fill in your Alexa verification code
+  yandex: # fill in your Yandex verification code
+  baidu: # fill in your Baidu verification code
+  facebook: # fill in your Facebook verification code
 
 # ↑ --------------------------
 # The end of `jekyll-seo-tag` settings


### PR DESCRIPTION
## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Description
I would like to pass site verification in more search engines except Google using meta tags.

## Solution
Change default configuration to make it visible that multiple services could be used for verification according to [Jekyll SEO tags usage documentation](https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/usage.md) as it took a while for me to figure it out, it may be useful for others to see it right away.