### PR TITLE
perf: improve `<hr>` visibility in dark mode

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -129,6 +129,11 @@ kbd {
   box-shadow: inset 0 -2px 0 var(--kbd-wrap-color);
 }
 
+hr {
+  border-color: var(--main-border-color);
+  opacity: 1;
+}
+
 footer {
   background-color: var(--main-bg);
   height: $footer-height;

--- a/_sass/colors/typography-dark.scss
+++ b/_sass/colors/typography-dark.scss
@@ -104,10 +104,6 @@
     display: none;
   }
 
-  hr {
-    border-color: var(--main-border-color);
-  }
-
   /* categories */
   .categories.card,
   .list-group-item {


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
Horizontal rule is barely visible on dark theme, but has good contrast on light theme.

**Before fix:**
![image](https://github.com/cotes2020/jekyll-theme-chirpy/assets/10548881/aa7ce0e6-92e0-4519-a06a-d35267c54938)

**After fix:**
![image](https://github.com/cotes2020/jekyll-theme-chirpy/assets/10548881/c4b18860-eadc-4133-898f-950be3c329df)

## Additional context
**Root cause:** from the [beginning](https://github.com/cotes2020/jekyll-theme-chirpy/commit/b7266aceace24f21e360fd68b308269f67e655da#diff-5d99ff0381ab34cb79b58aaaa1d7f15464055e1f382085dad91272f93b61db90R90).
