### PR TITLE
fix: correct the base URL parameter name

### DIFF
--- a/_includes/img-url.html
+++ b/_includes/img-url.html
@@ -29,9 +29,9 @@
     %}
 
     {% if include.absolute %}
-      {% assign url = site.url | append: site.base_url | append: url %}
+      {% assign url = site.url | append: site.baseurl | append: url %}
     {% else %}
-      {% assign url = site.base_url | append: url %}
+      {% assign url = site.baseurl | append: url %}
     {% endif %}
   {% endunless %}
 {%- endif -%}


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Correct `site.base_url` to `site.baseurl`

## Additional context

#1553 introduced
