### PR TITLE
refactor: use explicit url for goatcounter

### DIFF
--- a/_includes/analytics/goatcounter.html
+++ b/_includes/analytics/goatcounter.html
@@ -1,6 +1,6 @@
 <!-- GoatCounter -->
 <script
   async
-  src="//gc.zgo.at/count.js"
+  src="https://gc.zgo.at/count.js"
   data-goatcounter="https://{{ site.analytics.goatcounter.id }}.goatcounter.com/count"
 ></script>


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
Explicit GoatCounter URL was changed to a protocol-relative URL while doing refactoring #1543 which causes issues.

```
Run bundle exec htmlproofer _site \
Running 3 checks (Scripts, Links, Images) in ["_site"] on *.html files...

Checking [18](https://github.com/kungfux/kungfux.github.io/actions/runs/8101471704/job/22141725592#step:6:19)0 internal links
Checking internal link hashes in [19](https://github.com/kungfux/kungfux.github.io/actions/runs/8101471704/job/22141725592#step:6:20) files
Ran on 88 files!


For the Scripts check, the following failures were found:

* At _site/404.html:1:

  script link //gc.zgo.at/count.js is a protocol-relative URL, use explicit https:// instead

* At _site/about/index.html:51:

  script link //gc.zgo.at/count.js is a protocol-relative URL, use explicit https:// instead
...
```

## Additional context
This is not released yet and introduced by #1543 
