### PR TITLE
refactor: change alternate url for embed video file

### DIFF
--- a/_includes/embed/video.html
+++ b/_includes/embed/video.html
@@ -32,7 +32,7 @@
 
 <p>
   <video class="embed-video file" src="{{ video_url }}" {{ poster }} {{ attributes }}>
-    Your browser doesn't support HTML video. Here is a <a href="{{ url }}">link to the video</a> instead.
+    Your browser doesn't support HTML video. Here is a <a href="{{ video_url }}">link to the video</a> instead.
   </video>
   <em>{{ include.title }}</em>
 </p>


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
Incorrect variable is being used for an embeded video file alternate URL.

```
Run bundle exec htmlproofer _site \
Running 3 checks (Scripts, Links, Images) in ["_site"] on *.html files...


Checking 1[8](https://github.com/kungfux/kungfux.github.io/actions/runs/8101279120/job/22141127637#step:6:9)0 internal links
Checking internal link hashes in 1[9](https://github.com/kungfux/kungfux.github.io/actions/runs/8101279120/job/22141127637#step:6:10) files
Ran on 88 files!

For the Links check, the following failures were found:


* At _site/posts/streaming-api-and-how-to-stop-data-flow-to-test-it/index.html:[10](https://github.com/kungfux/kungfux.github.io/actions/runs/8101279120/job/22141127637#step:6:11)6:

  'a' tag is missing a reference
```

## Additional context
This is not released yet and introduced by #1558 