### PR TITLE
fix: search result prompt is empty

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -82,6 +82,6 @@ layout: compress
       {% include mermaid.html %}
     {% endif %}
 
-    {% include_cached search-loader.html %}
+    {% include_cached search-loader.html lang=lang %}
   </body>
 </html>


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Missing pass parameter `site.lang` leads to null search result.

## Additional context
- Fixes #1582
