### PR TITLE
feat(i18n): allow `page.lang` to override `site.lang`

### DIFF
--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -33,7 +33,7 @@
   or page.layout == 'category'
   or page.layout == 'tag'
 %}
-  {% assign locale = site.lang | split: '-' | first %}
+  {% assign locale = include.lang | split: '-' | first %}
 
   {% assign urls = urls
     | append: ','

--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -33,7 +33,7 @@
   or page.layout == 'category'
   or page.layout == 'tag'
 %}
-  {% assign locale = page.lang | default: site.lang | split: '-' | first %}
+  {% assign locale = include.lang | split: '-' | first %}
 
   {% assign urls = urls
     | append: ','

--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -33,7 +33,7 @@
   or page.layout == 'category'
   or page.layout == 'tag'
 %}
-  {% assign locale = include.lang | split: '-' | first %}
+  {% assign locale = page.lang | default: site.lang | split: '-' | first %}
 
   {% assign urls = urls
     | append: ','

--- a/_includes/lang.html
+++ b/_includes/lang.html
@@ -1,10 +1,8 @@
 {% comment %}
   Detect appearance language and return it through variable "lang"
 {% endcomment %}
-{% if site.data.locales[page.lang] %}
-  {% assign lang = page.lang %}
-{% else if site.data.locales[site.lang] %}
-  {% assign lang = site.lang %}
-{% else %}
+{% assign lang = page.lang | default: site.lang %}
+
+{% unless site.data.locales[lang] %}
   {% assign lang = 'en' %}
-{% endif %}
+{% endunless %}

--- a/_includes/lang.html
+++ b/_includes/lang.html
@@ -1,8 +1,10 @@
 {% comment %}
   Detect appearance language and return it through variable "lang"
 {% endcomment %}
-{% assign lang = page.lang | default: site.lang %}
-
-{% unless site.data.locales[lang] %}
+{% if site.data.locales[page.lang] %}
+  {% assign lang = page.lang %}
+{% elsif site.data.locales[site.lang] %}
+  {% assign lang = site.lang %}
+{% else %}
   {% assign lang = 'en' %}
-{% endunless %}
+{% endif %}

--- a/_includes/lang.html
+++ b/_includes/lang.html
@@ -1,7 +1,9 @@
 {% comment %}
   Detect appearance language and return it through variable "lang"
 {% endcomment %}
-{% if site.data.locales[site.lang] %}
+{% if site.data.locales[page.lang] %}
+  {% assign lang = page.lang %}
+{% else if site.data.locales[site.lang] %}
   {% assign lang = site.lang %}
 {% else %}
   {% assign lang = 'en' %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,7 +12,8 @@ layout: compress
   {% capture prefer_mode %}data-mode="{{ site.theme_mode }}"{% endcapture %}
 {% endif %}
 
-<html lang="{{ lang }}" {{ prefer_mode }}>
+<!-- `site.alt_lang` can specify a language different from the UI -->
+<html lang="{{ page.lang | default: site.alt_lang | default: site.lang }}" {{ prefer_mode }}>
   {% include head.html %}
 
   <body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -76,7 +76,7 @@ layout: compress
 
     <!-- JavaScripts -->
 
-    {% include js-selector.html %}
+    {% include js-selector.html lang=lang %}
 
     {% if page.mermaid %}
       {% include mermaid.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,8 +12,7 @@ layout: compress
   {% capture prefer_mode %}data-mode="{{ site.theme_mode }}"{% endcapture %}
 {% endif %}
 
-<!-- `site.alt_lang` can specify a language different from the UI -->
-<html lang="{{ site.alt_lang | default: site.lang }}" {{ prefer_mode }}>
+<html lang="{{ lang }}" {{ prefer_mode }}>
   {% include head.html %}
 
   <body>
@@ -76,10 +75,10 @@ layout: compress
 
     <!-- JavaScripts -->
 
-    {% include js-selector.html %}
+    {% include js-selector.html lang=lang %}
 
     {% if page.mermaid %}
-      {% include mermaid.html %}
+      {% include mermaid.html lang=lang %}
     {% endif %}
 
     {% include_cached search-loader.html lang=lang %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -75,10 +75,10 @@ layout: compress
 
     <!-- JavaScripts -->
 
-    {% include js-selector.html lang=lang %}
+    {% include js-selector.html %}
 
     {% if page.mermaid %}
-      {% include mermaid.html lang=lang %}
+      {% include mermaid.html %}
     {% endif %}
 
     {% include_cached search-loader.html lang=lang %}


### PR DESCRIPTION
## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Description
Allow `lang` on page/post to override `site.lang`.

This is useful to create folders (collections) of different languages. For example, I have folders `_en`, `_ru` and `_tr` (relative urls `en`, `ru` and `tr`), and then define these as collections in `_config.xml`:
```yaml
collections:
  en:
    output: true
  ru:
    output: true
  tr:
    output: true

defaults:
  - scope:
      path: ""
      type: en
    values:
      lang: en
  - scope:
      path: ""
      type: tr
    values:
      lang: tr-TR
  - scope:
      path: ""
      type: ru
    values:
      lang: ru-RU
```

It's also possible to just put `lang: ru-RU` directly into the page front matter.

## Additional context
I removed usage of `site.alt_lang` in the `html lang` tag of `default` layout because I'm not sure what that was for. If there's a reason for it then I could put it back.

I don't exactly know what `js-selector.html` is doing with `lang`, so I couldn't test it, but the change seems obvious.
