### PR TITLE
feat: make post description customizable

### DIFF
--- a/_data/origin/cors.yml
+++ b/_data/origin/cors.yml
@@ -13,7 +13,7 @@ cdns:
 
 # fonts
 
-webfonts: https://fonts.googleapis.com/css2?family=Lato&family=Source+Sans+Pro:wght@400;600;700;900&display=swap
+webfonts: https://fonts.googleapis.com/css2?family=Lato:wght@300;400&family=Source+Sans+Pro:wght@400;600;700;900&display=swap
 
 # Libraries
 

--- a/_includes/post-description.html
+++ b/_includes/post-description.html
@@ -1,12 +1,16 @@
-{% comment %}
+{%- comment -%}
   Get post description or generate it from the post content.
-{% endcomment %}
+{%- endcomment -%}
 
-{% assign max_length = include.max_length | default: 200 %}
+{%- assign max_length = include.max_length | default: 200 -%}
 
-{% if post.description %}
-  {{ post.description | strip | truncate: max_length }}
-{% else %}
-  {% include no-linenos.html content=post.content %}
-  {{ content | markdownify | strip_html | truncate: max_length | escape }}
-{% endif %}
+{%- capture description -%}
+{%- if post.description -%}
+  {{- post.description -}}
+{%- else -%}
+  {%- include no-linenos.html content=post.content -%}
+  {{- content | markdownify | strip_html -}}
+{%- endif -%}
+{%- endcapture -%}
+
+{{- description | strip | truncate: max_length | escape -}}

--- a/_includes/post-description.html
+++ b/_includes/post-description.html
@@ -3,8 +3,9 @@
 {% endcomment %}
 
 {% assign max_length = include.max_length | default: 200 %}
+
 {% if post.description %}
-  {{ post.description | strip | truncate: max_length | escape }}
+  {{ post.description | strip | truncate: max_length }}
 {% else %}
   {% include no-linenos.html content=post.content %}
   {{ content | markdownify | strip_html | truncate: max_length | escape }}

--- a/_includes/post-description.html
+++ b/_includes/post-description.html
@@ -1,0 +1,11 @@
+{% comment %}
+  Get post description or generate it from the post content.
+{% endcomment %}
+
+{% assign max_length = include.max_length | default: 200 %}
+{% if post.description %}
+  {{ post.description | strip | truncate: max_length | escape }}
+{% else %}
+  {% include no-linenos.html content=post.content %}
+  {{ content | markdownify | strip_html | truncate: max_length | escape }}
+{% endif %}

--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -82,8 +82,7 @@
               <h4 class="pt-0 my-2">{{ post.title }}</h4>
               <div class="text-muted">
                 <p>
-                  {% include no-linenos.html content=post.content %}
-                  {{ content | markdownify | strip_html | truncate: 200 | escape }}
+                  {% include post-description.html max_length=200 %}
                 </p>
               </div>
             </div>

--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -81,9 +81,7 @@
               {% include datetime.html date=post.date lang=include.lang %}
               <h4 class="pt-0 my-2">{{ post.title }}</h4>
               <div class="text-muted">
-                <p>
-                  {% include post-description.html max_length=200 %}
-                </p>
+                <p>{% include post-description.html %}</p>
               </div>
             </div>
           </a>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,7 +2,6 @@
 layout: default
 refactor: true
 ---
-
 {% include lang.html %}
 
 {% assign pinned = site.posts | where: 'pin', 'true' %}
@@ -73,8 +72,7 @@ refactor: true
 
             <div class="card-text content mt-0 mb-3">
               <p>
-                {% include no-linenos.html content=post.content %}
-                {{ content | markdownify | strip_html | truncate: 200 | escape }}
+                {% include post-description.html max_length=300 %}
               </p>
             </div>
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,6 +2,7 @@
 layout: default
 refactor: true
 ---
+
 {% include lang.html %}
 
 {% assign pinned = site.posts | where: 'pin', 'true' %}
@@ -71,9 +72,7 @@ refactor: true
             <h1 class="card-title my-2 mt-md-0">{{ post.title }}</h1>
 
             <div class="card-text content mt-0 mb-3">
-              <p>
-                {% include post-description.html max_length=300 %}
-              </p>
+              <p>{% include post-description.html %}</p>
             </div>
 
             <div class="post-meta flex-grow-1 d-flex align-items-end">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,7 @@ tail_includes:
   <header>
     <h1 data-toc-skip>{{ page.title }}</h1>
     {% if page.description %}
-      <p class="mb-4">{{ page.description }}</p>
+      <p class="post-desc fw-light mb-4">{{ page.description }}</p>
     {% endif %}
 
     <div class="post-meta text-muted">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,6 +14,9 @@ tail_includes:
 <article class="px-1">
   <header>
     <h1 data-toc-skip>{{ page.title }}</h1>
+    {% if page.description %}
+      <p class="mb-4">{{ page.description }}</p>
+    {% endif %}
 
     <div class="post-meta text-muted">
       <!-- published date -->

--- a/_posts/2019-08-08-text-and-typography.md
+++ b/_posts/2019-08-08-text-and-typography.md
@@ -1,5 +1,6 @@
 ---
 title: Text and Typography
+description: See markdown syntax rendering on Chirpy, so you can use it as an example of writing.
 author: cotes
 date: 2019-08-08 11:33:00 +0800
 categories: [Blogging, Demo]

--- a/_posts/2019-08-08-text-and-typography.md
+++ b/_posts/2019-08-08-text-and-typography.md
@@ -1,6 +1,6 @@
 ---
 title: Text and Typography
-description: See markdown syntax rendering on Chirpy, so you can use it as an example of writing.
+description: Examples of text, typography, math equations, diagrams, flowcharts, pictures, videos, and more.
 author: cotes
 date: 2019-08-08 11:33:00 +0800
 categories: [Blogging, Demo]
@@ -13,8 +13,6 @@ image:
   lqip: data:image/webp;base64,UklGRpoAAABXRUJQVlA4WAoAAAAQAAAADwAABwAAQUxQSDIAAAARL0AmbZurmr57yyIiqE8oiG0bejIYEQTgqiDA9vqnsUSI6H+oAERp2HZ65qP/VIAWAFZQOCBCAAAA8AEAnQEqEAAIAAVAfCWkAALp8sF8rgRgAP7o9FDvMCkMde9PK7euH5M1m6VWoDXf2FkP3BqV0ZYbO6NA/VFIAAAA
   alt: Responsive rendering of Chirpy theme on multiple devices.
 ---
-
-This post is to show Markdown syntax rendering on [**Chirpy**](https://github.com/cotes2020/jekyll-theme-chirpy/fork), you can also use it as an example of writing. Now, let's start looking at text and typography.
 
 ## Headings
 

--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -1,5 +1,6 @@
 ---
 title: Writing a New Post
+description: This tutorial will guide you how to write a post in the Chirpy template.
 author: cotes
 date: 2019-08-08 14:10:00 +0800
 categories: [Blogging, Tutorial]
@@ -72,6 +73,17 @@ Having said that, the key `author` can also identify multiple entries.
 
 > The benefit of reading the author information from the file `_data/authors.yml`{: .filepath } is that the page will have the meta tag `twitter:creator`, which enriches the [Twitter Cards](https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started#card-and-content-attribution) and is good for SEO.
 {: .prompt-info }
+
+### Post description
+
+The `description` field is optional. If it isn't defined, the first words of the post are used to display on the `Home` page for a list of posts, in the `Further Reading` section, and in the XML of the RSS feed. If you don't want to display the auto-generated description for the post, you can customize it using the `description` field in the `Front Matter` as follows:
+
+```yaml
+---
+title: Post title
+description: Short summary of the post
+---
+```
 
 ## Table of Contents
 

--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -1,6 +1,5 @@
 ---
 title: Writing a New Post
-description: This tutorial will guide you how to write a post in the Chirpy template.
 author: cotes
 date: 2019-08-08 14:10:00 +0800
 categories: [Blogging, Tutorial]
@@ -74,16 +73,17 @@ Having said that, the key `author` can also identify multiple entries.
 > The benefit of reading the author information from the file `_data/authors.yml`{: .filepath } is that the page will have the meta tag `twitter:creator`, which enriches the [Twitter Cards](https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started#card-and-content-attribution) and is good for SEO.
 {: .prompt-info }
 
-### Post description
+### Post Description
 
-The `description` field is optional. If it isn't defined, the first words of the post are used to display on the `Home` page for a list of posts, in the `Further Reading` section, and in the XML of the RSS feed. If you don't want to display the auto-generated description for the post, you can customize it using the `description` field in the `Front Matter` as follows:
+By default, the first words of the post are used to display on the home page for a list of posts, in the _Further Reading_ section, and in the XML of the RSS feed. If you don't want to display the auto-generated description for the post, you can customize it using the `description` field in the _Front Matter_ as follows:
 
 ```yaml
 ---
-title: Post title
-description: Short summary of the post
+description: Short summary of the post.
 ---
 ```
+
+Additionally, the `description` text will also be displayed under the post title on the post's page.
 
 ## Table of Contents
 

--- a/_posts/2019-08-09-getting-started.md
+++ b/_posts/2019-08-09-getting-started.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Started
+description: A quick start guide to help you get started with Chirpy.
 author: cotes
 date: 2019-08-09 20:55:00 +0800
 categories: [Blogging, Tutorial]

--- a/_posts/2019-08-09-getting-started.md
+++ b/_posts/2019-08-09-getting-started.md
@@ -1,6 +1,8 @@
 ---
 title: Getting Started
-description: A quick start guide to help you get started with Chirpy.
+description: >-
+  Get started with Chirpy basics in this comprehensive overview.
+  You will learn how to install, configure, and use your first Chirpy-based website, as well as deploy it to a web server.
 author: cotes
 date: 2019-08-09 20:55:00 +0800
 categories: [Blogging, Tutorial]

--- a/_posts/2019-08-11-customize-the-favicon.md
+++ b/_posts/2019-08-11-customize-the-favicon.md
@@ -1,6 +1,5 @@
 ---
 title: Customize the Favicon
-description: How to customize the favicon of Chirpy.
 author: cotes
 date: 2019-08-11 00:34:00 +0800
 categories: [Blogging, Tutorial]

--- a/_posts/2019-08-11-customize-the-favicon.md
+++ b/_posts/2019-08-11-customize-the-favicon.md
@@ -1,5 +1,6 @@
 ---
 title: Customize the Favicon
+description: How to customize the favicon of Chirpy.
 author: cotes
 date: 2019-08-11 00:34:00 +0800
 categories: [Blogging, Tutorial]

--- a/_sass/layout/post.scss
+++ b/_sass/layout/post.scss
@@ -15,9 +15,10 @@
 }
 
 header {
-  p {
-    font-family: $font-family-heading;
-    font-size: 1.1rem;
+  .post-desc {
+    @extend %heading;
+
+    font-size: 1.125rem;
     line-height: 1.6;
   }
 

--- a/_sass/layout/post.scss
+++ b/_sass/layout/post.scss
@@ -14,19 +14,27 @@
   padding-right: $pr;
 }
 
-h1 + .post-meta {
-  span + span::before {
-    @include dot;
+header {
+  p {
+    font-family: $font-family-heading;
+    font-size: 1.1rem;
+    line-height: 1.6;
   }
 
-  em,
-  time {
-    @extend %text-highlight;
-  }
+  .post-meta {
+    span + span::before {
+      @include dot;
+    }
 
-  em {
-    a {
-      color: inherit;
+    em,
+    time {
+      @extend %text-highlight;
+    }
+
+    em {
+      a {
+        color: inherit;
+      }
     }
   }
 }

--- a/assets/feed.xml
+++ b/assets/feed.xml
@@ -45,14 +45,7 @@ permalink: /feed.xml
     {% endfor %}
   {% endif %}
 
-  {% if post.summary %}
-    <summary>{{ post.summary | strip }}</summary>
-  {% else %}
-    <summary>
-      {% include no-linenos.html content=post.content %}
-      {{ content  | strip_html | truncate: 400 }}
-    </summary>
-  {% endif %}
+  <summary>{% include post-description.html max_length=1000 %}</summary>
 
   </entry>
 {% endfor %}

--- a/assets/feed.xml
+++ b/assets/feed.xml
@@ -45,7 +45,7 @@ permalink: /feed.xml
     {% endfor %}
   {% endif %}
 
-  <summary>{% include post-description.html max_length=1000 %}</summary>
+  <summary>{% include post-description.html max_length=400 %}</summary>
 
   </entry>
 {% endfor %}


### PR DESCRIPTION
## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
I would like to have control over the post summary that appears on the `Home` page, in the `Further Reading` section, and in the RSS feed instead of the auto-generated one that is not always great for this purpose.

ref #1596
ref #1516 

## BREAKING CHANGE
A similar feature `summary` already exists and is used for RSS feed summary exclusively. However, it's support is removed with this PR and replaced by `description`.

## Renderings

- Homepage
  <img width="761" alt="Screenshot 2024-03-18 at 18 40 43" src="https://github.com/cotes2020/jekyll-theme-chirpy/assets/11371340/703e30b7-3d42-4858-9b54-c127817220ac">

- Posts page
  <img width="805" alt="Screenshot 2024-03-18 at 18 41 11" src="https://github.com/cotes2020/jekyll-theme-chirpy/assets/11371340/4bad459d-a575-456f-a49b-4c9f3d0a2e08">