### PR TITLE
fix: veriables hook does not overwrite default variables

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -1,7 +1,7 @@
 @import 'colors/typography-light';
 @import 'colors/typography-dark';
-@import 'addon/variables';
 @import 'variables-hook';
+@import 'addon/variables';
 @import 'addon/module';
 @import 'addon/syntax';
 @import 'addon/commons';


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->
Fix the issue that veriables-hook does not overwrite default variables

## Additional context
Fixes #1603
