### PR TITLE
feat(footer): display theme version

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -34,7 +34,7 @@
     {%- endcapture -%}
 
     {%- capture _theme -%}
-      <a href="https://github.com/cotes2020/jekyll-theme-chirpy" target="_blank" rel="noopener">Chirpy</a>
+      <a href="https://github.com/cotes2020/jekyll-theme-chirpy" target="_blank" rel="noopener">Chirpy@{{ theme.version }}</a>
     {%- endcapture -%}
 
     {{ site.data.locales[include.lang].meta | replace: ':PLATFORM', _platform | replace: ':THEME', _theme }}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -34,7 +34,14 @@
     {%- endcapture -%}
 
     {%- capture _theme -%}
-      <a href="https://github.com/cotes2020/jekyll-theme-chirpy" target="_blank" rel="noopener">Chirpy@{{ theme.version }}</a>
+      <a
+        data-bs-toggle="tooltip"
+        data-bs-placement="top"
+        title="v{{ theme.version }}"
+        href="https://github.com/cotes2020/jekyll-theme-chirpy"
+        target="_blank"
+        rel="noopener"
+      >Chirpy</a>
     {%- endcapture -%}
 
     {{ site.data.locales[include.lang].meta | replace: ':PLATFORM', _platform | replace: ':THEME', _theme }}


### PR DESCRIPTION
## Type of change
- [x] Improvement (refactoring and improving code)

## Description
Summary: Display theme version.
Motivation: When I'm working on my blog, I like to see the current version of the theme I'm using.
 - It's helpful to see which version we use, it helps to avoid unnecessary steps to find the theme version.
 - It also makes it easier to write reports, as users can see the version they have a problem with right away. Especially if the user specifies theme like this: ">= 5.6".
