### PR TITLE
fix:  use `https` for Weibo sharing URL

### DIFF
--- a/_data/share.yml
+++ b/_data/share.yml
@@ -22,7 +22,7 @@ platforms:
   #
   # - type: Weibo
   #   icon: "fab fa-weibo"
-  #   link: "http://service.weibo.com/share/share.php?title=TITLE&url=URL"
+  #   link: "https://service.weibo.com/share/share.php?title=TITLE&url=URL"
   #
   # - type: Mastodon
   #   icon: "fa-brands fa-mastodon"


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->
"Test Site" fails when Weibo sharing is enabled.
like [this](https://github.com/long-910/long-910.github.io/actions/runs/8309620866/job/22741192309)
```
  http://service.weibo.com/share/share.php?title=XXX&url=YYY is not an HTTPS link
```

## Additional context
<!-- e.g. Fixes #(issue) -->
