### PR TITLE
feat: add 'jump to main content' button

### DIFF
--- a/_data/locales/ar.yml
+++ b/_data/locales/ar.yml
@@ -49,6 +49,8 @@ notification:
   update_found: يتوفر اصدار جديد للمحتوى.
   update: تحديث
 
+jump_to_main_content: الانتقال إلى المحتوى الرئيسي
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/bg-BG.yml
+++ b/_data/locales/bg-BG.yml
@@ -49,6 +49,8 @@ notification:
   update_found: Налична е нова версия на съдържанието.
   update: Обнови
 
+jump_to_main_content: Премини към основното съдържание
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/cs-CZ.yml
+++ b/_data/locales/cs-CZ.yml
@@ -49,6 +49,8 @@ notification:
   update_found: Je k dispozici nová verze obsahu.
   update: Aktualizace
 
+jump_to_main_content: Přejít k hlavnímu obsahu
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/de-DE.yml
+++ b/_data/locales/de-DE.yml
@@ -48,6 +48,8 @@ notification:
   update_found: Eine neue Version ist verfügbar.
   update: Neue Version
 
+jump_to_main_content: Zum Hauptinhalt springen
+
 # ----- Posts related labels -----
 
 post:
@@ -76,7 +78,7 @@ df:
   post:
     strftime: "%d.%m.%Y"
     dayjs: "DD.MM.YYYY"
-    
+
 # categories page
 categories:
   category_measure:

--- a/_data/locales/el-GR.yml
+++ b/_data/locales/el-GR.yml
@@ -49,6 +49,8 @@ notification:
   update_found: Υπάρχει διαθέσιμη μια νέα έκδοση του περιεχομένου.
   update: Ενημέρωση
 
+jump_to_main_content: Μετάβαση στο κυρίως περιεχόμενο
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -49,6 +49,8 @@ notification:
   update_found: A new version of content is available.
   update: Update
 
+jump_to_main_content: Jump to main content
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/es-ES.yml
+++ b/_data/locales/es-ES.yml
@@ -49,6 +49,8 @@ notification:
   update_found: Hay una nueva versión de contenido disponible.
   update: Actualizar
 
+jump_to_main_content: Saltar al contenido principal
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/fi-FI.yml
+++ b/_data/locales/fi-FI.yml
@@ -48,6 +48,8 @@ notification:
   update_found: Uusi versio sisällöstä on saatavilla.
   update: Päivitä
 
+jump_to_main_content: Siirry pääsisältöön
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/fr-FR.yml
+++ b/_data/locales/fr-FR.yml
@@ -49,6 +49,8 @@ notification:
   update_found: Une nouvelle version du contenu est disponible.
   update: Mise à jour
 
+jump_to_main_content: Aller au contenu principal
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/hu-HU.yml
+++ b/_data/locales/hu-HU.yml
@@ -51,6 +51,8 @@ notification:
   update_found: Elérhető a tartalom új verziója.
   update: Frissítés
 
+jump_to_main_content: Ugrás a tartalomhoz
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/id-ID.yml
+++ b/_data/locales/id-ID.yml
@@ -49,6 +49,8 @@ notification:
   update_found: Versi konten baru tersedia.
   update: Perbarui
 
+jump_to_main_content: Loncat ke konten utama
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/it-IT.yml
+++ b/_data/locales/it-IT.yml
@@ -48,6 +48,8 @@ notification:
   update_found: Nuova versione del contenuto disponibile.
   update: Aggiornamento
 
+jump_to_main_content: Vai al contenuto principale
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/ko-KR.yml
+++ b/_data/locales/ko-KR.yml
@@ -49,6 +49,8 @@ notification:
   update_found: 새 버전의 콘텐츠를 사용할 수 있습니다.
   update: 업데이트
 
+jump_to_main_content: 기본 콘텐츠로 이동
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/my-MM.yml
+++ b/_data/locales/my-MM.yml
@@ -49,6 +49,8 @@ notification:
   update_found: အကြောင်းအရာဗားရှင်းအသစ်ကို ရနိုင်ပါပြီ။
   update: အပ်ဒိတ်
 
+jump_to_main_content: အဓိက အကြောင်းအရာတွေဆီ ခုန်ချပါ
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/pt-BR.yml
+++ b/_data/locales/pt-BR.yml
@@ -49,6 +49,8 @@ notification:
   update_found: Uma nova versão do conteúdo está disponível.
   update: atualização
 
+jump_to_main_content: Saltar para o conteúdo principal
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/ru-RU.yml
+++ b/_data/locales/ru-RU.yml
@@ -48,6 +48,8 @@ notification:
   update_found: Доступна новая версия контента.
   update: Обновить
 
+jump_to_main_content: Перейти к основному содержанию
+
 # ----- Posts related labels -----
 
 post:
@@ -76,7 +78,7 @@ df:
   post:
     strftime: "%d.%m.%Y"
     dayjs: "DD.MM.YYYY"
-    
+
 # categories page
 categories:
   category_measure:

--- a/_data/locales/sl-SI.yml
+++ b/_data/locales/sl-SI.yml
@@ -49,6 +49,8 @@ notification:
   update_found: Novejša različica vsebine je na voljo. #A new version of content is available.
   update: Posodobi #Update
 
+jump_to_main_content: Skok na glavno vsebino #Jump to main content
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/sv-SE.yml
+++ b/_data/locales/sv-SE.yml
@@ -49,6 +49,8 @@ notification:
   update_found: Det finns en ny version av innehållet.
   update: Uppdatera sidan
 
+jump_to_main_content: Hoppa till huvudinnehåll
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/th.yml
+++ b/_data/locales/th.yml
@@ -49,6 +49,8 @@ notification:
   update_found: มีเวอร์ชันใหม่ของเนื้อหา
   update: อัปเดต
 
+jump_to_main_content: ข้ามไปที่เนื้อหาหลัก
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/tr-TR.yml
+++ b/_data/locales/tr-TR.yml
@@ -49,6 +49,8 @@ notification:
   update_found: İçeriğin yeni bir sürümü mevcut.
   update: Güncelle
 
+jump_to_main_content: Ana içeriğe atla
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/uk-UA.yml
+++ b/_data/locales/uk-UA.yml
@@ -49,6 +49,8 @@ notification:
   update_found: Доступна нова версія вмісту.
   update: Оновлення
 
+jump_to_main_content: Перейти до основного контенту
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/vi-VN.yml
+++ b/_data/locales/vi-VN.yml
@@ -48,6 +48,8 @@ notification:
   update_found: Đã có phiên bản mới của nội dung.
   update: Cập nhật
 
+jump_to_main_content: Chuyển đến nội dung chính
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/zh-CN.yml
+++ b/_data/locales/zh-CN.yml
@@ -48,6 +48,8 @@ notification:
   update_found: 发现新版本的内容。
   update: 更新
 
+jump_to_main_content: 跳到主要内容
+
 # ----- Posts related labels -----
 
 post:

--- a/_data/locales/zh-TW.yml
+++ b/_data/locales/zh-TW.yml
@@ -48,6 +48,8 @@ notification:
   update_found: 發現新版本更新。
   update: 更新
 
+jump_to_main_content: 跳到主要內容
+
 # ----- Posts related labels -----
 
 post:

--- a/_includes/jump-to-content.html
+++ b/_includes/jump-to-content.html
@@ -1,0 +1,6 @@
+<!-- Jump to content link -->
+<div class="jump-to-main-content">
+  <a class="jump-to-main-content__button btn btn-outline-primary" href="#main-content">
+    {{ site.data.locales[include.lang].jump_to_main_content }}
+  </a>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,6 +17,7 @@ layout: compress
   {% include head.html %}
 
   <body>
+    {% include jump-to-content.html lang=lang %}
     {% include sidebar.html lang=lang %}
 
     <div id="main-wrapper" class="d-flex justify-content-center">
@@ -24,7 +25,7 @@ layout: compress
         {% include topbar.html lang=lang %}
 
         <div class="row flex-grow-1">
-          <main aria-label="Main Content" class="col-12 col-lg-11 col-xl-9 px-md-4">
+          <main aria-label="Main Content" id="main-content" class="col-12 col-lg-11 col-xl-9 px-md-4">
             {% if layout.refactor or layout.layout == 'default' %}
               {% include refactor-content.html content=content lang=lang %}
             {% else %}

--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -35,6 +35,27 @@ body {
   font-family: $font-family-base;
 }
 
+/* --- Skip to Content --- */
+
+.jump-to-main-content {
+  left: -100vw;
+  position: absolute;
+
+  &__button {
+    z-index: 100; // Must be higher than the sidebar
+    top: 0.5em;
+    left: 0.75em;
+    padding: 0.5em;
+    position: fixed;
+    transform: translateY(-10em);
+    transition: transform .2s ease-in-out;
+
+    &:focus {
+      transform: translateY(0em);
+    }
+  }
+}
+
 /* --- Typography --- */
 
 @for $i from 1 through 5 {


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->
Adds a configurable `Jump to main content` hidden button that is displayed only when focused by pressing tab.

This makes it easier to navigate the blog just using a keyboard or screen reader.
1. Navigate to your blog
1. Press tab to go to the first tab stop: `Jump to main content`
1. Press enter, and the focus switches to the `<main>` element. Subsequent `tab`s will now be within the body of the `home`/`post`/`categories`/`tags`/`archive`/`about` page.

Also added i18n strings for all of the languages currently supported. I used Google Translate so I can't promise it's accurate, but it's a pretty standard message so I'm fairly confident that it'll be somewhat accurate.

## Additional context
<!-- e.g. Fixes #(issue) -->
- https://www.scottohara.me/blog/2017/04/14/inclusively-hidden.html

## How it looks
<img width="399" alt="image" src="https://github.com/cotes2020/jekyll-theme-chirpy/assets/12701930/3b440b4c-3415-47fe-b36d-ba1bc9113fdf">