### PR TITLE
feat: add support for giscus strict title matching

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -114,6 +114,7 @@ comments:
     category:
     category_id:
     mapping: # optional, default to 'pathname'
+    strict: # optional, default to '0'
     input_position: # optional, default to 'bottom'
     lang: # optional, default to the value of `site.lang`
     reactions_enabled: # optional, default to the value of `1`

--- a/_includes/comments/giscus.html
+++ b/_includes/comments/giscus.html
@@ -25,6 +25,7 @@
       'data-category': '{{ site.comments.giscus.category }}',
       'data-category-id': '{{ site.comments.giscus.category_id }}',
       'data-mapping': '{{ site.comments.giscus.mapping | default: 'pathname' }}',
+      'data-strict' : '{{ site.comments.giscus.strict | default: '0' }}',
       'data-reactions-enabled': '{{ site.comments.giscus.reactions_enabled | default: '1' }}',
       'data-emit-metadata': '0',
       'data-theme': initTheme,


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->
I noticed that `giscus`'s `data-strict` option isn't being set, and can't be configured.
This may be a newer option that wasn't available when it was initially introduced.
Either way it's a pretty straight-forward change to add support and a default value.

## Additional context
<!-- e.g. Fixes #(issue) -->
<img width="723" alt="image" src="https://github.com/cotes2020/jekyll-theme-chirpy/assets/12701930/e4f09d35-b956-496d-b403-60f8f3eca7a7">

_[giscus.app](https://giscus.app/)_