### PR TITLE
fix: correct the attribute for the Twitter social image

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -39,7 +39,7 @@
     {%- endcapture -%}
 
     {%- capture twitter_image -%}
-      <meta property="twitter:card" content="summary_large_image" />
+      <meta name="twitter:card" content="summary_large_image" />
       <meta property="twitter:image" content="{{ img_url }}" />
     {%- endcapture -%}
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
**Problem**: I have noticed that social image preview is not always being displayed for Twitter and people reporting the same in #1599.

**Solution**: Follow Twitter [guidelines](https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started) for `meta` tags naming when we replace generated one by Jekyll.

## Additional context
I'm using [extension](https://chromewebstore.google.com/detail/social-share-preview/ggnikicjfklimmffbkhknndafpdlabib) to test these changes, but I assume the solution was tested in #1599.