### PR TITLE
fix(seo): correct social preview image path inside `<meta>` tag

### DIFF
--- a/_includes/img-url.html
+++ b/_includes/img-url.html
@@ -14,24 +14,26 @@
 
 {%- if url -%}
   {% unless url contains ':' %}
-    {%- comment -%} CND URL {%- endcomment -%}
-    {% assign prefix = site.img_cdn | default: '' %}
-
     {%- comment -%} Add page image path prefix {%- endcomment -%}
     {% assign url = include.img_path | default: '' | append: '/' | append: url %}
 
-    {% assign url = prefix
-      | append: '/'
-      | append: url
-      | replace: '///', '/'
-      | replace: '//', '/'
-      | replace: ':', ':/'
-    %}
+    {%- comment -%} CND URL {%- endcomment -%}
+    {% if site.img_cdn %}
+      {% assign url = site.img_cdn
+        | append: '/'
+        | append: url
+        | replace: '///', '/'
+        | replace: '//', '/'
+        | replace: ':/', '://'
+      %}
 
-    {% if include.absolute %}
-      {% assign url = site.url | append: site.baseurl | append: url %}
-    {% else %}
-      {% assign url = site.baseurl | append: url %}
+      {% unless site.img_cdn contains ':' %}
+        {% if include.absolute %}
+          {% assign url = site.url | append: site.baseurl | append: url %}
+        {% else %}
+          {% assign url = site.baseurl | append: url %}
+        {% endif %}
+      {% endunless %}
     {% endif %}
   {% endunless %}
 {%- endif -%}


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Issue

When a cross-domain `site.img_cdn` is set and the default site-wide social graph URL (`site.social_preview_image`) is a local path, the URL of the social preview image inside the SEO tag is incorrect.

### Input

```yaml
# _config.yml
img_cdn: https://chirpy.cotes.page
social_preview_image: /commons/devices-mockup.png
```

### Output

```html
# The HTML page source
<meta property="og:image" content="https://chirpy.cotes.pagehttps://chirpy.cotes.page/commons/devices-mockup.png">
<meta property="twitter:image" content="https://chirpy.cotes.pagehttps://chirpy-img.netlify.app/commons/devices-mockup.png">
```

## What's changed

This PR corrects the logic of `_includes/img-url.html` to fix the above issue.
