### PR TITLE
Fix references to comment parameter `site.comments.provider`

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,5 +1,5 @@
-<!--  The comments switcher -->
-{% if page.comments and site.comments.active %}
-  {% capture path %}comments/{{ site.comments.active }}.html{% endcapture %}
+<!-- The comments switcher -->
+{% if page.comments and site.comments.provider %}
+  {% capture path %}comments/{{ site.comments.provider }}.html{% endcapture %}
   {% include {{ path }} %}
 {% endif %}


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->

I can't see the comments, because

In #1563, the parameter name of the comment has been changed from `active` to `provider`, but the change was not applied to `comments switcher`.


## Additional context
<!-- e.g. Fixes #(issue) -->
https://github.com/cotes2020/jekyll-theme-chirpy/pull/1563