### PR TITLE
fix: An error occurred due to assets/js/dist/*.min.js files that are set in gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,3 @@ package-lock.json
 
 # IDE configurations
 .idea
-
-# Misc
-assets/js/dist


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Development environment

- OS : Windows
- Jekyll Chirpy(v6.5.5) 

---

<img width="898" alt="스크린샷 2024-04-03 오후 1 43 39" src="https://github.com/cotes2020/jekyll-theme-chirpy/assets/123640210/6bb5cb9f-fcb1-4b74-a354-440f1399b341">

---

When I deployed my blog with the Chirpy theme, I saw this errors. There was no problem on local, but if I deployed without this modification, the blog function did not work properly because there were no files related to assets/js/dist/*.min.js on GitHub.

Because of the same reason, I deleted assets/js/dist/*.min.js from gitignore.
After making these changes, the build and deployment were successful without any issues.