### PR TITLE
Support MathJax extension, e.g. physics package

### DIFF
--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -75,6 +75,11 @@
   <script>
     /* see: <https://docs.mathjax.org/en/latest/options/input/tex.html#tex-options> */
     MathJax = {
+      /* specify caching the mathematical fonts as global SVG fonts */ 
+      svg: { fontCache: 'global'},
+      /* load package */
+      loader: {load: ['[tex]/physics']},
+      /* More extensions can be found: https://docs.mathjax.org/en/latest/input/tex/extensions/index.html*/
       tex: {
         /* start/end delimiter pairs for in-line math */
         inlineMath: [
@@ -86,6 +91,8 @@
           ['$$', '$$'],
           ['\\[', '\\]']
         ],
+        /* load package */
+        packages: {'[+]': ['physics']},
         /* equation numbering */
         tags: 'ams'
       }

--- a/_posts/2019-08-08-text-and-typography.md
+++ b/_posts/2019-08-08-text-and-typography.md
@@ -152,6 +152,12 @@ When $a \ne 0$, there are two solutions to $ax^2 + bx + c = 0$ and they are
 
 $$ x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$
 
+We can also use the physics package in MathJax to render mathematical expressions:
+
+$$
+i G_{\alpha\beta}(\vb{x}t,\vb{x}'t') = \frac{\mel{\Psi_0}{\hat{\mathsf{T}}[\hat{\psi}_{H\alpha}(\vb{x}t)\hat{\psi}_{H\beta}^\dagger(\vb{x}'t')]}{\Psi_0}}{\braket{\Psi_0}{\Psi_0}}
+$$
+
 ## Mermaid SVG
 
 ```mermaid


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->
MathJax provides many extensions that help us input mathematical expressions more conveniently. Among them, the `physics` package is particularly important for STEM majors, as it allows us to easily input matrices, Dirac notation, adjust bracket sizes, and more.

I modified `_includes/js-selector.html` to add support for the `physics` package. Additionally, I also set MathJax to use global SVG font caching, which helps improve performance, especially on websites with multiple pages containing mathematical formulas. This reduces the time required to regenerate fonts each time a page is loaded.

I also added an example using the `physics` package in `_posts/2019-08-08-text-and-typography.md`.

More extensions of MathJax can be found [here](https://docs.mathjax.org/en/latest/input/tex/extensions/index.html)

## Additional context
<!-- e.g. Fixes #(issue) -->
Fixed #622 