### PR TITLE
feat(MathJax): Add support for MathJax extension, e.g. physics package

### DIFF
--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -75,6 +75,11 @@
   <script>
     /* see: <https://docs.mathjax.org/en/latest/options/input/tex.html#tex-options> */
     MathJax = {
+      /* specify caching the mathematical fonts as global SVG fonts */ 
+      svg: { fontCache: 'global'},
+      /* load package */
+      loader: {load: ['[tex]/physics']},
+      /* More extensions can be found: https://docs.mathjax.org/en/latest/input/tex/extensions/index.html*/
       tex: {
         /* start/end delimiter pairs for in-line math */
         inlineMath: [
@@ -86,6 +91,8 @@
           ['$$', '$$'],
           ['\\[', '\\]']
         ],
+        /* load package */
+        packages: {'[+]': ['physics']},
         /* equation numbering */
         tags: 'ams'
       }

--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -75,8 +75,6 @@
   <script>
     /* see: <https://docs.mathjax.org/en/latest/options/input/tex.html#tex-options> */
     MathJax = {
-      /* specify caching the mathematical fonts as global SVG fonts */ 
-      svg: { fontCache: 'global'},
       /* load package */
       loader: {load: ['[tex]/physics']},
       /* More extensions can be found: https://docs.mathjax.org/en/latest/input/tex/extensions/index.html*/

--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -70,35 +70,6 @@
 {% capture script %}{{ js_dist }}{{ js }}.min.js{% endcapture %}
 <script defer src="{{ script | relative_url }}"></script>
 
-{% if page.math %}
-  <!-- MathJax -->
-  <script>
-    /* see: <https://docs.mathjax.org/en/latest/options/input/tex.html#tex-options> */
-    MathJax = {
-      /* load package */
-      loader: {load: ['[tex]/physics']},
-      /* More extensions can be found: https://docs.mathjax.org/en/latest/input/tex/extensions/index.html*/
-      tex: {
-        /* start/end delimiter pairs for in-line math */
-        inlineMath: [
-          ['$', '$'],
-          ['\\(', '\\)']
-        ],
-        /* start/end delimiter pairs for display math */
-        displayMath: [
-          ['$$', '$$'],
-          ['\\[', '\\]']
-        ],
-        /* load package */
-        packages: {'[+]': ['physics']},
-        /* equation numbering */
-        tags: 'ams'
-      }
-    };
-  </script>
-  <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
-  <script id="MathJax-script" async src="{{ site.data.origin[type].mathjax.js | relative_url }}"></script>
-{% endif %}
 
 <!-- Pageviews -->
 {% if page.layout == 'post' %}

--- a/_includes/mathjax-support.html
+++ b/_includes/mathjax-support.html
@@ -1,0 +1,22 @@
+<script>
+/* see: <https://docs.mathjax.org/en/latest/options/input/tex.html#tex-options> */
+/* MathJax extensions can be found: <https://docs.mathjax.org/en/latest/input/tex/extensions/index.html> */
+MathJax = {
+    tex: {
+    /* start/end delimiter pairs for in-line math */
+    inlineMath: [
+        ['$', '$'],
+        ['\\(', '\\)']
+    ],
+    /* start/end delimiter pairs for display math */
+    displayMath: [
+        ['$$', '$$'],
+        ['\\[', '\\]']
+    ],
+    /* equation numbering */
+    tags: 'ams'
+    }
+};
+</script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
+<script id="MathJax-script" async src="{{ site.data.origin[type].mathjax.js | relative_url }}"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -78,6 +78,11 @@ layout: compress
 
     {% include js-selector.html lang=lang %}
 
+    <!-- MathJax -->
+    {% if page.math %}
+      {% include mathjax-support.html %}
+    {% endif %}
+
     {% if page.mermaid %}
       {% include mermaid.html %}
     {% endif %}

--- a/_posts/2019-08-08-text-and-typography.md
+++ b/_posts/2019-08-08-text-and-typography.md
@@ -152,12 +152,6 @@ When $a \ne 0$, there are two solutions to $ax^2 + bx + c = 0$ and they are
 
 $$ x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$
 
-We can also use the physics package in MathJax to render mathematical expressions:
-
-$$
-i G_{\alpha\beta}(\vb{x}t,\vb{x}'t') = \frac{\mel{\Psi_0}{\hat{\mathsf{T}}[\hat{\psi}_{H\alpha}(\vb{x}t)\hat{\psi}_{H\beta}^\dagger(\vb{x}'t')]}{\Psi_0}}{\braket{\Psi_0}{\Psi_0}}
-$$
-
 ## Mermaid SVG
 
 ```mermaid

--- a/_posts/2019-08-08-text-and-typography.md
+++ b/_posts/2019-08-08-text-and-typography.md
@@ -152,6 +152,12 @@ When $a \ne 0$, there are two solutions to $ax^2 + bx + c = 0$ and they are
 
 $$ x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$
 
+We can also use the physics package in MathJax to render mathematical expressions:
+
+$$
+i G_{\alpha\beta}(\vb{x}t,\vb{x}'t') = \frac{\mel{\Psi_0}{\hat{\mathsf{T}}[\hat{\psi}_{H\alpha}(\vb{x}t)\hat{\psi}_{H\beta}^\dagger(\vb{x}'t')]}{\Psi_0}}{\braket{\Psi_0}{\Psi_0}}
+$$
+
 ## Mermaid SVG
 
 ```mermaid


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->
MathJax provides many extensions that help us input mathematical expressions more conveniently. Among them, the [physics package](https://docs.mathjax.org/en/latest/input/tex/extensions/physics.html) is particularly important for STEM majors, as it allows us to easily input matrices, Dirac notation, adjust bracket sizes, and more.

I modified `_includes/js-selector.html` to add support for the `physics` package. I also added an example using the `physics` package in `_posts/2019-08-08-text-and-typography.md`.

More extensions of MathJax can be found [here](https://docs.mathjax.org/en/latest/input/tex/extensions/index.html)

## Additional context
<!-- e.g. Fixes #(issue) -->
Fixed #622 