### PR TITLE
fix(pwa): avoid caching large files

### DIFF
--- a/assets/js/pwa/sw.js
+++ b/assets/js/pwa/sw.js
@@ -84,7 +84,7 @@ self.addEventListener('fetch', (event) => {
       return fetch(event.request).then((response) => {
         const url = event.request.url;
 
-        if (purge || event.request.method !== 'GET' || !verifyUrl(url)) {
+        if (purge || response.status !== 200 || event.request.method !== 'GET' || !verifyUrl(url)) {
           return response;
         }
 

--- a/assets/js/pwa/sw.js
+++ b/assets/js/pwa/sw.js
@@ -75,6 +75,10 @@ self.addEventListener('message', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
+  if (event.request.headers.has('range')) {
+    return;
+  }
+
   event.respondWith(
     caches.match(event.request).then((response) => {
       if (response) {
@@ -84,7 +88,7 @@ self.addEventListener('fetch', (event) => {
       return fetch(event.request).then((response) => {
         const url = event.request.url;
 
-        if (purge || response.status === 206 || event.request.method !== 'GET' || !verifyUrl(url)) {
+        if (purge || event.request.method !== 'GET' || !verifyUrl(url)) {
           return response;
         }
 

--- a/assets/js/pwa/sw.js
+++ b/assets/js/pwa/sw.js
@@ -84,7 +84,7 @@ self.addEventListener('fetch', (event) => {
       return fetch(event.request).then((response) => {
         const url = event.request.url;
 
-        if (purge || response.status !== 200 || event.request.method !== 'GET' || !verifyUrl(url)) {
+        if (purge || response.status === 206 || event.request.method !== 'GET' || !verifyUrl(url)) {
           return response;
         }
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
I'm going to try to solve an issue related to caching files that are chunked for transfer (usually they have a 206 status) that we have discussed here GH-1651. To avoid this error, we should only cache files that have a response code of 200.

![image](https://github.com/cotes2020/jekyll-theme-chirpy/assets/18232567/92d6bdb3-124e-46d9-983e-1b7f21e04c12)