### PR TITLE
Add .jekyll-metadata to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ Gemfile.lock
 .jekyll-cache
 _site
 
+# Jekyll incremental (-I) build
+.jekyll-metadata
+
 # RubyGems
 *.gem
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,8 @@ Gemfile.lock
 
 # Jekyll cache
 .jekyll-cache
-_site
-
-# Jekyll incremental (-I) build
 .jekyll-metadata
+_site
 
 # RubyGems
 *.gem


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description

When running jekyll using the param `--incremental` or `-I`, the file `.jekyll-metadata` gets generated. According to Jekyll documentation, it should be added to `.gitignore`.

> This helps Jekyll keep track of which files have not been modified since the site was last built, and which files will need to be regenerated on the next build. Only created when using [incremental regeneration](https://jekyllrb.com/docs/configuration/incremental-regeneration/) (e.g.: with jekyll serve -I). This file will not be included in the generated site. It’s probably a good idea to add this to your .gitignore file.

Reference: https://jekyllrb.com/docs/structure/

## Additional context

n/a
