### PR TITLE
Specify the node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v4
+        with:
+          node-version: latest
 
       - name: Build Assets
         run: npm i && npm run build

--- a/.github/workflows/style-lint.yml
+++ b/.github/workflows/style-lint.yml
@@ -17,5 +17,7 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v4
+        with:
+          node-version: latest
       - run: npm i
       - run: npm test


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->

- [x] Improvement (refactoring and improving code)

## Description

The default version of the node in `actions/setup-node@v4` is `v18.20.2`, which is lower than the requirement of the dependency package ( >= `v20.8.1`)

## Additional context

See the section "Build Assets"  in <https://github.com/cotes2020/jekyll-theme-chirpy/actions/runs/8713275846/job/23901361027>

<details>
  <summary>Build Assets</summary>
 
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'semantic-release@23.0.8',
npm WARN EBADENGINE   required: { node: '>=20.8.1' },
npm WARN EBADENGINE   current: { node: 'v18.20.1', npm: '10.[5](https://github.com/cotes2020/jekyll-theme-chirpy/actions/runs/8713275846/job/23901361027#step:5:6).0' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@semantic-release/commit-analyzer@12.0.0',
npm WARN EBADENGINE   required: { node: '>=20.[8](https://github.com/cotes2020/jekyll-theme-chirpy/actions/runs/8713275846/job/23901361027#step:5:9).1' },
npm WARN EBADENGINE   current: { node: 'v18.20.1', npm: '[10](https://github.com/cotes2020/jekyll-theme-chirpy/actions/runs/8713275846/job/23901361027#step:5:11).5.0' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@semantic-release/github@10.0.3',
npm WARN EBADENGINE   required: { node: '>=20.8.1' },
npm WARN EBADENGINE   current: { node: 'v18.20.1', npm: '10.5.0' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@semantic-release/npm@12.0.0',
npm WARN EBADENGINE   required: { node: '>=20.8.1' },
npm WARN EBADENGINE   current: { node: 'v18.20.1', npm: '10.5.0' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@semantic-release/release-notes-generator@13.0.0',
npm WARN EBADENGINE   required: { node: '>=20.8.1' },
npm WARN EBADENGINE   current: { node: 'v18.20.1', npm: '10.5.0' }
npm WARN EBADENGINE }
npm WARN deprecated read-pkg-up@[11](https://github.com/cotes2020/jekyll-theme-chirpy/actions/runs/8713275846/job/23901361027#step:5:12).0.0: Renamed to read-package-up
```
</details>