### PR TITLE
refactor: make Further Reading display the latest posts.

### DIFF
--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -21,11 +21,11 @@
   {% assign match_posts = match_posts | push: site.tags[tag] | uniq %}
 {% endfor %}
 
+{% assign match_posts = match_posts | reverse %}
 {% assign last_index = match_posts.size | minus: 1 %}
 {% assign score_list = '' | split: '' %}
 
-{% for j in (0..last_index) %}
-  {% assign i = last_index | minus: j %}
+{% for i in (0..last_index) %}
   {% assign post = match_posts[i] %}
 
   {% if post.url == page.url %}
@@ -55,14 +55,12 @@
 {% assign index_list = '' | split: '' %}
 
 {% if score_list.size > 0 %}
-  {% assign score_list = score_list | sort_nature | reverse %}
+  {% assign score_list = score_list | sort | reverse %}
   {% for entry in score_list limit: TOTAL_SIZE %}
     {% assign index = entry | split: SEPARATOR | last %}
     {% assign index_list = index_list | push: index %}
   {% endfor %}
 {% endif %}
-
-{% assign index_list = index_list | reverse %}
 
 {% assign relate_posts = '' | split: '' %}
 

--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -24,7 +24,8 @@
 {% assign last_index = match_posts.size | minus: 1 %}
 {% assign score_list = '' | split: '' %}
 
-{% for i in (0..last_index) %}
+{% for j in (0..last_index) %}
+  {% assign i = last_index | minus: j %}
   {% assign post = match_posts[i] %}
 
   {% if post.url == page.url %}
@@ -54,12 +55,14 @@
 {% assign index_list = '' | split: '' %}
 
 {% if score_list.size > 0 %}
-  {% assign score_list = score_list | sort | reverse %}
+  {% assign score_list = score_list | sort_nature | reverse %}
   {% for entry in score_list limit: TOTAL_SIZE %}
     {% assign index = entry | split: SEPARATOR | last %}
     {% assign index_list = index_list | push: index %}
   {% endfor %}
 {% endif %}
+
+{% assign index_list = index_list | reverse %}
 
 {% assign relate_posts = '' | split: '' %}
 


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
I modified the code in `_includes/related-posts.html` to enable **Further Reading** to display the latest posts, as stated in the title.

I need to explain why I made this change. 

Consider a scenario where we have five different posts, e.g.
```
_posts
├─ Title1.md
├─ Title2.md
├─ Title3.md
├─ Title4.md
└─ Title5.md
```
each of which has the **same score** calculated in `_includes/related-posts.html`. When we open any of these posts, Further Reading always displays the three oldest posts instead of the three most recently updated ones. 

### Before
As an example, when we open `Title4` post, It shows `Title1`, `Title2` and `Title3`,

![order2](https://github.com/cotes2020/jekyll-theme-chirpy/assets/100574401/217c4475-8dcd-4d32-a9c1-a1f07756ef32)

The same is true when opening `Title5`. No matter how many posts we write later, it will always display only the first 3 posts.

### After
We might prefer it to show the latest 3 posts, e.g. `Title2`, `Title3`, `Title5`. My PR can make the blog produce the following effects:

![order1](https://github.com/cotes2020/jekyll-theme-chirpy/assets/100574401/3ff41542-b4d0-47b7-9294-e96d8f2d5355)

## Additional context
I'm not familiar with Liquid, so these changes were based on my interpretation of the official documentation. There may be other ways to further simplify it, but it does work effectively.