### PR TITLE
fix: prevent footnote back arrow from becoming an emoji on IOS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -151,6 +151,7 @@ baseurl: ""
 # ------------ The following options are not recommended to be modified ------------------
 
 kramdown:
+  footnote_backlink: "&#8617;&#xfe0e;"
   syntax_highlighter: rouge
   syntax_highlighter_opts: # Rouge Options › https://github.com/jneen/rouge#full-options
     css_class: highlight


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->

The footnote back arrow will become emoji on IOS, see the following figure,

<img src="https://github.com/cotes2020/jekyll-theme-chirpy/assets/100574401/7ab4608b-4281-48b0-b25e-9b1f6752e34c" width="50%">

This problem is not caused by Jekyll, but by Kramdown and Apple, see [Kramdown](https://kramdown.gettalong.org/quickref.html#fnref:1) and [Jekyll](https://github.com/jekyll/jekyll/issues/3751) and [here](https://bendodson.com/weblog/2016/01/11/fixing-emoji-footnote-arrow-in-jekyll/#fn:kramdown).

Just add the following code to `_config.yml` can fix this problem:
```yml
kramdown:
  	  footnote_backlink: "&#8617;&#xfe0e;"
```
where `&#xfe0e;` is text presentation selector, used to request a text presentation for an emoji character, see [Unicode](https://www.unicode.org/reports/tr51/#def_text_presentation_selector).

You can see the following [examples](https://www.ii.com/unicode-variation-selectors-15-16/#_table_of_variation_selector_entities_meanings_and17examples):

![image](https://github.com/cotes2020/jekyll-theme-chirpy/assets/100574401/6d17b6fa-00fa-4b92-86ec-b5c22f97c209)


## Additional context

If you don't think this needs to be changed, you can close this PR at any time
