### PR TITLE
Enable Bluesky sharing

### DIFF
--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -26,3 +26,7 @@
 # - type: stack-overflow
 #   icon: 'fab fa-stack-overflow'
 #   url:  ''                  # Fill with your stackoverflow homepage
+#
+# - type: bluesky
+#   icon: 'fa-brands fa-bluesky'
+#   url: ''                   # Fill with your Bluesky profile link

--- a/_data/origin/cors.yml
+++ b/_data/origin/cors.yml
@@ -24,7 +24,7 @@ toc:
   js: https://cdn.jsdelivr.net/npm/tocbot@4.25.0/dist/tocbot.min.js
 
 fontawesome:
-  css: https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.1/css/all.min.css
+  css: https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css
 
 search:
   js: https://cdn.jsdelivr.net/npm/simple-jekyll-search@1.10.0/dest/simple-jekyll-search.min.js

--- a/_data/share.yml
+++ b/_data/share.yml
@@ -36,3 +36,7 @@ platforms:
   #       link: "https://fosstodon.org/"
   #     - label: photog.social
   #       link: "https://photog.social/"
+  #
+  # - type: Bluesky
+  #   icon: "fa-brands fa-bluesky"
+  #   link: "https://bsky.app/intent/compose?text=TITLE%20URL"


### PR DESCRIPTION
## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Description
- adds Bluesky sharing option
- adds Bluesky contact option
- updates the CDN deployment of Fontawesome to version 6.5.2 which is a dependency for Bluesky icons, and also brings it inline with the version included in the static assets.

## Additional context
n/a
