### PR TITLE
Goatcounter PV greater than 1K cannot be converted to numbers

### DIFF
--- a/_includes/pageviews/goatcounter.html
+++ b/_includes/pageviews/goatcounter.html
@@ -9,7 +9,8 @@
     fetch(url)
       .then((response) => response.json())
       .then((data) => {
-        pv.innerText = new Intl.NumberFormat().format(data.count);
+        const count = data.count.replace(/\s/g, '');
+        pv.innerText = new Intl.NumberFormat().format(count);
       })
       .catch((error) => {
         pv.innerText = '1';


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Description

The goatcounter PV report splits numbers with spaces, e.g. 1024 would be '1 024'

## Additional context
<!-- e.g. Fixes #(issue) -->
N/A
