### PR TITLE
Restore tzinfo dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,10 @@ gemspec
 group :test do
   gem "html-proofer", "~> 5.0"
 end
+
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
Build is failing on Windows.

```bash
$ ruby -v
ruby 3.3.1 (2024-04-23 revision c56cd86388) [x64-mingw-ucrt]

$ ./tools/run

> bundle exec jekyll s -l -H 127.0.0.1

Configuration file: C:/Projects/jekyll-theme-chirpy/_config.yml
  Dependency Error: Yikes! It looks like you don't have tzinfo or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. If you've run Jekyll with `bundle exec`, ensure that you have included the tzinfo gem in your Gemfile as well. The full error message from Ruby is: 'cannot load such file -- tzinfo' If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/!
jekyll 4.3.3 | Error:  tzinfo
C:/Ruby33-x64/lib/ruby/gems/3.3.0/gems/jekyll-4.3.3/lib/jekyll/external.rb:70:in `rescue in block in require_with_graceful_fail': tzinfo (Jekyll::Errors::MissingDependencyException)
```

## Additional context
Root cause: https://github.com/cotes2020/jekyll-theme-chirpy/commit/f87fdd0ea0b52291744fae14850bbfe931282a95

Can we restore the dependency or is there a better solution?