### PR TITLE
Add progress indicator to back-to-top button

### DIFF
--- a/_javascript/modules/components/back-to-top.js
+++ b/_javascript/modules/components/back-to-top.js
@@ -8,6 +8,15 @@ export function back2top() {
   window.addEventListener('scroll', () => {
     if (window.scrollY > 50) {
       btn.classList.add('show');
+
+      const circumference = 2 * 3.14 * 20;
+      const circle = document.querySelector('#progress-circle circle');
+      const scrollTop = window.scrollY;
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      const scrollFraction = scrollTop / docHeight;
+      const drawLength = circumference * scrollFraction;
+
+      circle.style.strokeDashoffset = circumference - drawLength;
     } else {
       btn.classList.remove('show');
     }

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -63,7 +63,10 @@ layout: compress
 
       <aside aria-label="Scroll to Top">
         <button id="back-to-top" type="button" class="btn btn-lg btn-box-shadow">
-          <i class="fas fa-angle-up"></i>
+          <i class="fas fa-angle-up"> </i>
+          <svg id="progress-circle" width="44" height="44">
+            <circle cx="22" cy="22" r="20" stroke-width="4" fill="none"></circle>
+          </svg>
         </button>
       </aside>
     </div>

--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -1157,6 +1157,20 @@ search {
     opacity: 1;
     visibility: visible;
   }
+
+  #progress-circle {
+    margin: -1px -1px;
+    top: -2.75rem;
+    position: relative;
+    transform: rotate(-90deg);
+  }
+
+  #progress-circle circle {
+    stroke: var(--toc-highlight);
+    stroke-dasharray: 2 * 3.14 * 20;
+    stroke-dashoffset: 2 * 3.14 * 20;
+    transition: stroke-dashoffset 0.2s;
+  }
 }
 
 #notification {


### PR DESCRIPTION
## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Description
I would like to:
- Show progress as I read posts
- Make the back-to-top button more visible

![scrollToTop](https://github.com/cotes2020/jekyll-theme-chirpy/assets/10548881/95dea24a-8388-4e33-a65e-e7d06583f403)

While the technical solution requires modifications, please let me know what do you think about this idea?