### PR TITLE
Remove package `rollup-plugin-license`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Gemfile.lock
 .jekyll-cache
 .jekyll-metadata
 _site
+_app
 
 # RubyGems
 *.gem

--- a/_config.yml
+++ b/_config.yml
@@ -168,6 +168,9 @@ collections:
   tabs:
     output: true
     sort_by: order
+  app:
+    output: true
+    permalink: /:name
 
 defaults:
   - scope:
@@ -190,10 +193,6 @@ defaults:
     values:
       layout: page
       permalink: /:title/
-  - scope:
-      path: assets/js/dist
-    values:
-      swcache: true
 
 sass:
   style: compressed

--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -6,8 +6,6 @@
 
 <!-- layout specified -->
 
-{% assign js_dist = '/assets/js/dist/' %}
-
 {% if page.layout == 'post' or page.layout == 'page' or page.layout == 'home' %}
   {% assign urls = urls | append: ',' | append: site.data.origin[type]['lazy-polyfill'].js %}
 
@@ -62,7 +60,8 @@
     {% assign js = 'commons' %}
 {% endcase %}
 
-{% capture script %}{{ js_dist }}{{ js }}.min.js{% endcapture %}
+{% capture script %}/assets/js/dist/{{ js }}.min.js{% endcapture %}
+
 <script src="{{ script | relative_url }}"></script>
 
 {% if page.math %}
@@ -93,7 +92,7 @@
 {% if jekyll.environment == 'production' %}
   <!-- PWA -->
   {% if site.pwa.enabled %}
-    <script defer src="{{ 'app.min.js' | prepend: js_dist | relative_url }}"></script>
+    <script defer src="{{ 'app.min.js' | relative_url }}"></script>
   {% endif %}
 
   <!-- Web Analytics -->

--- a/_javascript/_copyright
+++ b/_javascript/_copyright
@@ -1,1 +1,0 @@
-Chirpy v<%= pkg.version %> | © 2019 <%= pkg.author %> | <%= pkg.license %> Licensed | <%= pkg.homepage %>

--- a/_javascript/pwa/_frontmatter
+++ b/_javascript/pwa/_frontmatter
@@ -1,3 +1,0 @@
----
-permalink: /:basename
----

--- a/jekyll-theme-chirpy.gemspec
+++ b/jekyll-theme-chirpy.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f|
-    f.match(%r!^((_(includes|layouts|sass|(data\/(locales|origin)))|assets)\/|README|LICENSE)!i)
+    f.match(%r!^((_(includes|layouts|sass|app|(data\/(locales|origin)))|assets)\/|README|LICENSE)!i)
   }
 
   spec.metadata = {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "author": "Cotes Chung",
   "license": "MIT",
+  "since": 2019,
   "bugs": {
     "url": "https://github.com/cotes2020/jekyll-theme-chirpy/issues"
   },
@@ -43,7 +44,6 @@
     "husky": "^9.0.11",
     "purgecss": "^6.0.0",
     "rollup": "^4.18.0",
-    "rollup-plugin-license": "^3.4.0",
     "semantic-release": "^24.0.0",
     "stylelint": "^16.6.1",
     "stylelint-config-standard-scss": "^13.1.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,18 +19,11 @@ const isProd = process.env.BUILD === 'production';
 
 function cleanup(...directories) {
   for (const dir of directories) {
-    if (typeof dir !== 'string') {
-      console.warn('Invalid directory:', dir);
-      return;
-    }
-
-    if (fs.existsSync(dir)) {
-      fs.rm(dir, { recursive: true, force: true }, (err) => {
-        if (err) {
-          throw err;
-        }
-      });
-    }
+    fs.rm(dir, { recursive: true, force: true }, (err) => {
+      if (err) {
+        console.error(`Failed to remove directory ${dir}: ${err}`);
+      }
+    });
   }
 }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,38 +1,50 @@
 import babel from '@rollup/plugin-babel';
 import terser from '@rollup/plugin-terser';
-import license from 'rollup-plugin-license';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import fs from 'fs';
-import path from 'path';
 import yaml from '@rollup/plugin-yaml';
+import fs from 'fs';
+import pkg from './package.json';
 
 const SRC_DEFAULT = '_javascript';
 const DIST_DEFAULT = 'assets/js/dist';
+
 const SRC_PWA = `${SRC_DEFAULT}/pwa`;
+const DIST_PWA = '_app';
+
+const banner = `/*!
+ * ${pkg.name} v${pkg.version} | © ${pkg.since} ${pkg.author} | ${pkg.license} Licensed | ${pkg.homepage}
+ */`;
 
 const isProd = process.env.BUILD === 'production';
 
-if (fs.existsSync(DIST_DEFAULT)) {
-  fs.rm(DIST_DEFAULT, { recursive: true, force: true }, (err) => {
-    if (err) {
-      throw err;
+function cleanup(...directories) {
+  for (const dir of directories) {
+    if (typeof dir !== 'string') {
+      console.warn('Invalid directory:', dir);
+      return;
     }
-  });
+
+    if (fs.existsSync(dir)) {
+      fs.rm(dir, { recursive: true, force: true }, (err) => {
+        if (err) {
+          throw err;
+        }
+      });
+    }
+  }
 }
 
 function build(filename, opts = {}) {
   const src = opts.src || SRC_DEFAULT;
   const dist = opts.dist || DIST_DEFAULT;
-  const bannerUrl =
-    opts.bannerUrl || path.join(__dirname, SRC_DEFAULT, '_copyright');
-  const commentStyle = opts.commentStyle || 'ignored';
 
   return {
-    input: [`${src}/${filename}.js`],
+    input: `${src}/${filename}.js`,
     output: {
       file: `${dist}/${filename}.min.js`,
       format: 'iife',
       name: 'Chirpy',
+      banner,
       sourcemap: !isProd
     },
     watch: {
@@ -46,17 +58,12 @@ function build(filename, opts = {}) {
       }),
       nodeResolve(),
       yaml(),
-      isProd && commentStyle === 'none' && terser(),
-      license({
-        banner: {
-          commentStyle,
-          content: { file: bannerUrl }
-        }
-      }),
-      isProd && commentStyle !== 'none' && terser()
+      isProd && terser()
     ]
   };
 }
+
+cleanup(DIST_DEFAULT, DIST_PWA);
 
 export default [
   build('commons'),
@@ -65,10 +72,6 @@ export default [
   build('page'),
   build('post'),
   build('misc'),
-  build('app', { src: SRC_PWA }),
-  build('sw', {
-    src: SRC_PWA,
-    bannerUrl: path.join(__dirname, SRC_PWA, '_frontmatter'),
-    commentStyle: 'none'
-  })
+  build('app', { src: SRC_PWA, dist: DIST_PWA }),
+  build('sw', { src: SRC_PWA, dist: DIST_PWA })
 ];

--- a/tools/init.sh
+++ b/tools/init.sh
@@ -92,7 +92,7 @@ init_files() {
   npm i && npm run build
 
   # track the CSS/JS output
-  _sedi "/.*\/dist$/d" .gitignore
+  _sedi "/.*\/dist$/d;/^_app$/d" .gitignore
 }
 
 commit() {

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -17,6 +17,7 @@ CONFIG="_config.yml"
 
 CSS_DIST="_sass/dist"
 JS_DIST="assets/js/dist"
+PWA_DIST="_app"
 
 FILES=(
   "$GEM_SPEC"
@@ -111,20 +112,13 @@ prepare() {
 
 ## Build a Gem package
 build_gem() {
-  if $opt_pkg; then
-    BACKUP_PATH="$(mktemp -d)"
-    mkdir -p "$BACKUP_PATH"/css "$BACKUP_PATH"/js
-    [[ -d $CSS_DIST ]] && cp "$CSS_DIST"/* "$BACKUP_PATH"/css
-    [[ -d $JS_DIST ]] && cp "$JS_DIST"/* "$BACKUP_PATH"/js
-  fi
-
   # Remove unnecessary theme settings
   sed -i -E "s/(^timezone:).*/\1/;s/(^cdn:).*/\1/;s/(^avatar:).*/\1/" $CONFIG
   rm -f ./*.gem
 
   npm run build
   # add CSS/JS distribution files to gem package
-  git add "$CSS_DIST" "$JS_DIST" -f
+  git add "$CSS_DIST" "$JS_DIST" "$PWA_DIST" -f
 
   echo -e "\n> gem build $GEM_SPEC\n"
   gem build "$GEM_SPEC"
@@ -132,14 +126,6 @@ build_gem() {
   echo -e "\n> Resume file changes ...\n"
   git reset
   git checkout .
-
-  if $opt_pkg; then
-    # restore the dist files for future development
-    mkdir -p "$CSS_DIST" "$JS_DIST"
-    cp "$BACKUP_PATH"/css/* "$CSS_DIST"
-    cp "$BACKUP_PATH"/js/* "$JS_DIST"
-    rm -rf "$BACKUP_PATH"
-  fi
 }
 
 # Push the gem to RubyGems.org (using $GEM_HOST_API_KEY)


### PR DESCRIPTION
## Description

The `rollup-plugin-license` has been using too many deprecated dependencies, so it is necessary to remove it.

As an alternative, this changes uses Rollup `output.banner` to insert copyright information. Since `terser` runs after `output`, it is not possible to insert the Front Matter defining permlink for `sw.js` through the same way (Jekyll Front Matter is YAML rather than JS, which would cause errors with terser).

Therefore, _Jekyll Collection_ is now used to add permlink to `sw.js`, with the collection named `app`, and the directory placed in `_app`. This directory is not tracked by git, but it will be included when building the gem.

## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->

- [x] Improvement (refactoring and improving code)


