### PR TITLE
feat(ui): make `info-prompt` icon looks like letter i

### DIFF
--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -107,8 +107,8 @@ blockquote {
     }
   }
 
-  @include prompt('tip', '\f0eb', 'regular');
-  @include prompt('info', '\f06a', null, 180);
+  @include prompt('tip', '\f0eb', $fa-style: 'regular');
+  @include prompt('info', '\f06a', $rotate: 180);
   @include prompt('warning', '\f06a');
   @include prompt('danger', '\f071');
 }

--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -108,7 +108,7 @@ blockquote {
   }
 
   @include prompt('tip', '\f0eb', 'regular');
-  @include prompt('info', '\f06a');
+  @include prompt('info', '\f06a', null, 180);
   @include prompt('warning', '\f06a');
   @include prompt('danger', '\f071');
 }

--- a/_sass/addon/module.scss
+++ b/_sass/addon/module.scss
@@ -194,11 +194,6 @@
     &::before {
       content: $fa-content;
       color: var(--prompt-#{$type}-icon-color);
-
-      @if not $fa-style {
-        $fa-style: 'solid';
-      }
-
       font: var(--fa-font-#{$fa-style});
 
       @if $rotate != 0 {

--- a/_sass/addon/module.scss
+++ b/_sass/addon/module.scss
@@ -187,14 +187,23 @@
   transform: translateX(-50%);
 }
 
-@mixin prompt($type, $fa-content, $fa-style: 'solid') {
+@mixin prompt($type, $fa-content, $fa-style: 'solid', $rotate: 0) {
   &.prompt-#{$type} {
     background-color: var(--prompt-#{$type}-bg);
 
     &::before {
       content: $fa-content;
       color: var(--prompt-#{$type}-icon-color);
+
+      @if not $fa-style {
+        $fa-style: 'solid';
+      }
+
       font: var(--fa-font-#{$fa-style});
+
+      @if $rotate != 0 {
+        transform: rotate(#{$rotate}deg);
+      }
     }
   }
 }


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Improvement (refactoring and improving code)


## Description

The info prompt icon is flipped 180 degrees to visually match the letter `i`, but does not duplicate the sidebar's "About" tab icon.

## Additional context

Resolves:

- #1130
- #1347

