### PR TITLE
Automate build tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ package-lock.json
 .vscode/*
 !.vscode/settings.json
 !.vscode/extensions.json
+!.vscode/tasks.json
 
 # Misc
 _sass/dist

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,66 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run Jekyll Server",
+      "type": "shell",
+      "command": "./tools/run.sh",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": [],
+      "detail": "Runs the Jekyll server with live reload."
+    },
+    {
+      "label": "Build Jekyll Site",
+      "type": "shell",
+      "command": "./tools/test.sh",
+      "group": {
+        "kind": "build"
+      },
+      "problemMatcher": [],
+      "detail": "Build the Jekyll site for production."
+    },
+    {
+      "label": "Build JS (watch)",
+      "type": "shell",
+      "command": "npm run watch:js",
+      "group": {
+        "kind": "build"
+      },
+      "problemMatcher": [],
+      "detail": "Build JS files in watch mode."
+    },
+    {
+      "label": "Build CSS",
+      "type": "shell",
+      "command": "npm run build:css",
+      "group": {
+        "kind": "build"
+      },
+      "problemMatcher": [],
+      "detail": "Build CSS files."
+    },
+    {
+      "label": "Build JS & CSS",
+      "type": "shell",
+      "command": "npm run build",
+      "group": {
+        "kind": "build"
+      },
+      "problemMatcher": [],
+      "detail": "Build JS & CSS for production."
+    },
+    {
+      "label": "Run Jekyll Server + Build JS (watch)",
+      "dependsOn": [
+        "Run Jekyll Server", "Build JS (watch)"
+      ],
+      "group": {
+        "kind": "build"
+      },
+      "detail": "Runs both the Jekyll server with live reload and build JS files in watch mode."
+    }
+  ]
+}


### PR DESCRIPTION
## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Description
Add `tasks.json` to automate typical tasks and improve dev experience.

### Usage
- When you open a project, watch task automatically starts, so you don't have to run tasks/commands manually
- Press `Ctrl+Shift+B` to run build and watch task
- Run any task from VS Code UI or command palette

## Additional info
Initial discussion has happened in [1781](https://github.com/cotes2020/jekyll-theme-chirpy/pull/1781#discussion_r1616431375).
[Documentation](https://go.microsoft.com/fwlink/?LinkId=733558) on tasks.