### PR TITLE
bugfix: prevent pageview requests caching

### DIFF
--- a/_javascript/pwa/sw.js
+++ b/_javascript/pwa/sw.js
@@ -3,6 +3,7 @@ import { baseurl } from '../../_config.yml';
 importScripts(`${baseurl}/assets/js/data/swconf.js`);
 
 const purge = swconf.purge;
+const interceptor = swconf.interceptor;
 
 function verifyUrl(url) {
   const requestUrl = new URL(url);
@@ -12,13 +13,13 @@ function verifyUrl(url) {
     return false;
   }
 
-  for (const denyUrl of swconf.denyUrls) {
-    if (requestUrl.href.startsWith(denyUrl)) {
+  for (const prefix of interceptor.urlPrefixes) {
+    if (requestUrl.href.startsWith(prefix)) {
       return false;
     }
   }
 
-  for (const path of swconf.denyPaths) {
+  for (const path of interceptor.paths) {
     if (requestPath.startsWith(path)) {
       return false;
     }

--- a/_javascript/pwa/sw.js
+++ b/_javascript/pwa/sw.js
@@ -5,7 +5,18 @@ importScripts(`${baseurl}/assets/js/data/swconf.js`);
 const purge = swconf.purge;
 
 function verifyUrl(url) {
-  const requestPath = new URL(url).pathname;
+  const requestUrl = new URL(url);
+  const requestPath = requestUrl.pathname;
+
+  if (!requestUrl.protocol.startsWith('http')) {
+    return false;
+  }
+
+  for (const denyUrl of swconf.denyUrls) {
+    if (requestUrl.href.startsWith(denyUrl)) {
+      return false;
+    }
+  }
 
   for (const path of swconf.denyPaths) {
     if (requestPath.startsWith(path)) {

--- a/assets/js/data/swconf.js
+++ b/assets/js/data/swconf.js
@@ -22,6 +22,13 @@ const swconf = {
       {% endfor %}
     ],
 
+    {%- comment -%} The request url starting with below part will not be cached. {%- endcomment -%}
+    denyUrls: [
+      {% if site.analytics.goatcounter.id != nil and site.pageviews.provider == 'goatcounter' %}
+        'https://{{ site.analytics.goatcounter.id }}.goatcounter.com/counter/'
+      {% endif %}
+    ],
+
     {%- comment -%} The request url with below path will not be cached. {%- endcomment -%}
     denyPaths: [
       {% for path in site.pwa.cache.deny_paths %}

--- a/assets/js/data/swconf.js
+++ b/assets/js/data/swconf.js
@@ -22,21 +22,24 @@ const swconf = {
       {% endfor %}
     ],
 
-    {%- comment -%} The request url starting with below part will not be cached. {%- endcomment -%}
-    denyUrls: [
-      {% if site.analytics.goatcounter.id != nil and site.pageviews.provider == 'goatcounter' %}
-        'https://{{ site.analytics.goatcounter.id }}.goatcounter.com/counter/'
-      {% endif %}
-    ],
+    interceptor: {
+      {%- comment -%} URLs containing the following paths will not be cached. {%- endcomment -%}
+      paths: [
+        {% for path in site.pwa.cache.deny_paths %}
+          {% unless path == empty %}
+            '{{ path | relative_url }}'{%- unless forloop.last -%},{%- endunless -%}
+          {% endunless  %}
+        {% endfor %}
+      ],
 
-    {%- comment -%} The request url with below path will not be cached. {%- endcomment -%}
-    denyPaths: [
-      {% for path in site.pwa.cache.deny_paths %}
-        {% unless path == empty %}
-          '{{ path | relative_url }}'{%- unless forloop.last -%},{%- endunless -%}
-        {% endunless  %}
-      {% endfor %}
-    ],
+      {%- comment -%} URLs containing the following prefixes will not be cached. {%- endcomment -%}
+      urlPrefixes: [
+        {% if site.analytics.goatcounter.id != nil and site.pageviews.provider == 'goatcounter' %}
+          'https://{{ site.analytics.goatcounter.id }}.goatcounter.com/counter/'
+        {% endif %}
+      ]
+    },
+
     purge: false
   {% else %}
     purge: true


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
To retrieve pageviews we send `GET` request from `_includes/pageviews/goatcounter.html`. When PWA is enabled, the response is cached and so the pageview counter is not updated as expected.

## Additional context
I see two possible ways to fix this behavior:
1. Make `GET` requests unique
2. Avoid caching these requests

Option 1 is easy fix, applied in this PR but has it's drawbacks e.g. utilize cache.

Option 2 seems preferable. However, it requires changes in `_javascript/pwa/sw.js` to support non-relative paths.
Please let me know your thoughts on this.