### PR TITLE
ci: added lfs support

### DIFF
--- a/.github/workflows/starter/pages-deploy.yml
+++ b/.github/workflows/starter/pages-deploy.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          lfs: true
           # submodules: true
           # If using the 'assets' git submodule from Chirpy Starter, uncomment above
           # (See: https://github.com/cotes2020/chirpy-starter/tree/main/assets)


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Improvement (refactoring and improving code)

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->
Videos can easily take a lot of memory in disk, surpassing the 100MiB limit of GitHub, now that Chirpy supports videos I think it should support building the site with lfs files.

In this PR I've only added a line to include lfs in the deploy action in order to be able to push the content to GitHub pages.

## Additional context
<!-- e.g. Fixes #(issue) -->
