### PR TITLE
refactor: improve the efficiency of `GLightbox` switching

### DIFF
--- a/_javascript/modules/components/img-popup.js
+++ b/_javascript/modules/components/img-popup.js
@@ -9,15 +9,18 @@ const lightImages = '.popup:not(.dark)';
 const darkImages = '.popup:not(.light)';
 let selector = lightImages;
 
-function updateImages(lightbox) {
+function updateImages(current, reverse) {
   if (selector === lightImages) {
     selector = darkImages;
   } else {
     selector = lightImages;
   }
 
-  lightbox.destroy();
-  lightbox = GLightbox({ selector: `${selector}` });
+  if (reverse === null) {
+    reverse = GLightbox({ selector: `${selector}` });
+  }
+
+  [current, reverse] = [reverse, current];
 }
 
 export function imgPopup() {
@@ -34,7 +37,8 @@ export function imgPopup() {
     selector = darkImages;
   }
 
-  let lightbox = GLightbox({ selector: `${selector}` });
+  let current = GLightbox({ selector: `${selector}` });
+  let reverse = null;
 
   if (document.getElementById('mode-toggle')) {
     window.addEventListener('message', (event) => {
@@ -43,7 +47,7 @@ export function imgPopup() {
         event.data &&
         event.data.direction === ModeToggle.ID
       ) {
-        updateImages(lightbox);
+        updateImages(current, reverse);
       }
     });
   }


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Improvement (refactoring and improving code)

## Description

Repeatedly using `GLightbox.destroy()` (>= 4 times) will cause `GLightbox` to fail to generate new objects

## Additional context

- #1883 
