### PR TITLE
Improve the JS build for PWA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ package-lock.json
 # Misc
 _sass/dist
 assets/js/dist
-_app

--- a/_config.yml
+++ b/_config.yml
@@ -170,9 +170,6 @@ collections:
   tabs:
     output: true
     sort_by: order
-  app:
-    output: true
-    permalink: /:name
 
 defaults:
   - scope:

--- a/jekyll-theme-chirpy.gemspec
+++ b/jekyll-theme-chirpy.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f|
-    f.match(%r!^((_(includes|layouts|sass|app|(data\/(locales|origin)))|assets)\/|README|LICENSE)!i)
+    f.match(%r!^((_(includes|layouts|sass|(data\/(locales|origin)))|assets)\/|README|LICENSE)!i)
   }
 
   spec.metadata = {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,9 +35,7 @@ function insertFrontmatter() {
   };
 }
 
-function build(filename, opts = {}) {
-  const { src = SRC_DEFAULT, jekyll = false } = opts;
-
+function build(filename, { src = SRC_DEFAULT, jekyll = false } = {}) {
   return {
     input: `${src}/${filename}.js`,
     output: {

--- a/tools/init.sh
+++ b/tools/init.sh
@@ -92,7 +92,7 @@ init_files() {
   npm i && npm run build
 
   # track the CSS/JS output
-  _sedi "/.*\/dist$/d;/^_app$/d" .gitignore
+  _sedi "/.*\/dist$/d" .gitignore
 }
 
 commit() {

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -17,7 +17,6 @@ CONFIG="_config.yml"
 
 CSS_DIST="_sass/dist"
 JS_DIST="assets/js/dist"
-PWA_DIST="_app"
 
 FILES=(
   "$GEM_SPEC"
@@ -118,7 +117,7 @@ build_gem() {
 
   npm run build
   # add CSS/JS distribution files to gem package
-  git add "$CSS_DIST" "$JS_DIST" "$PWA_DIST" -f
+  git add "$CSS_DIST" "$JS_DIST" -f
 
   echo -e "\n> gem build $GEM_SPEC\n"
   gem build "$GEM_SPEC"


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Improvement (refactoring and improving code)


## Description

In #1796, customized Jekyll collection `app` can't be passed through the gem to the user-end.

So now output PWA JS files to the default directory `assets/js/dist`, and create a new custom `rollup` plugin to insert the Jekyll font matter for them.

## Additional context

- #1796
