### PR TITLE
Fix `baseurl` not passed to `app.js`

### DIFF
--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -92,7 +92,10 @@
 {% if jekyll.environment == 'production' %}
   <!-- PWA -->
   {% if site.pwa.enabled %}
-    <script defer src="{{ 'app.min.js' | relative_url }}"></script>
+    <script
+      defer
+      src="{{ 'app.min.js' | relative_url }}?baseurl={{ site.baseurl | default: '' }}&register={{ site.pwa.cache.enabled }}"
+    ></script>
   {% endif %}
 
   <!-- Web Analytics -->

--- a/_javascript/pwa/app.js
+++ b/_javascript/pwa/app.js
@@ -1,15 +1,19 @@
-import { pwa, baseurl } from '../../_config.yml';
 import Toast from 'bootstrap/js/src/toast';
 
 if ('serviceWorker' in navigator) {
-  if (pwa.enabled) {
-    const swUrl = `${baseurl}/sw.min.js`;
+  // Get Jekyll config from URL parameters
+  const src = new URL(document.currentScript.src);
+  const register = src.searchParams.get('register');
+  const baseUrl = src.searchParams.get('baseurl');
+
+  if (register) {
+    const swUrl = `${baseUrl}/sw.min.js`;
     const notification = document.getElementById('notification');
     const btnRefresh = notification.querySelector('.toast-body>button');
     const popupWindow = Toast.getOrCreateInstance(notification);
 
     navigator.serviceWorker.register(swUrl).then((registration) => {
-      // In case the user ignores the notification
+      // Restore the update window that was last manually closed by the user
       if (registration.waiting) {
         popupWindow.show();
       }

--- a/_javascript/pwa/sw.js
+++ b/_javascript/pwa/sw.js
@@ -1,6 +1,4 @@
-import { baseurl } from '../../_config.yml';
-
-importScripts(`${baseurl}/assets/js/data/swconf.js`);
+importScripts('./assets/js/data/swconf.js');
 
 const purge = swconf.purge;
 const interceptor = swconf.interceptor;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",
-    "@rollup/plugin-yaml": "^4.1.2",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,6 @@
 import babel from '@rollup/plugin-babel';
 import terser from '@rollup/plugin-terser';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import yaml from '@rollup/plugin-yaml';
 import fs from 'fs';
 import pkg from './package.json';
 
@@ -43,7 +42,7 @@ function build(filename, { src = SRC_DEFAULT, jekyll = false } = {}) {
       format: 'iife',
       name: 'Chirpy',
       banner,
-      sourcemap: !isProd
+      sourcemap: !isProd && !jekyll
     },
     watch: {
       include: `${src}/**`
@@ -55,7 +54,6 @@ function build(filename, { src = SRC_DEFAULT, jekyll = false } = {}) {
         plugins: ['@babel/plugin-transform-class-properties']
       }),
       nodeResolve(),
-      yaml(),
       isProd && terser(),
       jekyll && insertFrontmatter()
     ]


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Description

In #1734, the expected behavior of reading options from `_config.yml` in `app.js` is limited to the site configuration state at the time of the `app.js` _Rollup_ build. This means that it does not capture user-defined `baseurl` (#1909).

Therefore, this has been modified to pass the baseurl to app.js via the URL to achieve the intended design.

## Additional context

- Affected versions: `v7.0.0` ~ `v7.0.1`
- Fixes #1909
