### PR TITLE
Remove `h1` element from site title

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -11,9 +11,7 @@
       {%- endif -%}
     </a>
 
-    <h1 class="site-title">
-      <a href="{{ '/' | relative_url }}">{{ site.title }}</a>
-    </h1>
+    <a class="site-title d-block" href="{{ '/' | relative_url }}">{{ site.title }}</a>
     <p class="site-subtitle fst-italic mb-0">{{ site.tagline }}</p>
   </header>
   <!-- .profile-wrapper -->

--- a/_sass/addon/commons.scss
+++ b/_sass/addon/commons.scss
@@ -738,6 +738,9 @@ $btn-mb: 0.5rem;
   }
 
   .site-title {
+    @extend %clickable-transition;
+    @extend %sidebar-link-hover;
+
     font-family: inherit;
     font-weight: 900;
     font-size: 1.75rem;
@@ -745,13 +748,8 @@ $btn-mb: 0.5rem;
     letter-spacing: 0.25px;
     margin-top: 1.25rem;
     margin-bottom: 0.5rem;
-
-    a {
-      @extend %clickable-transition;
-      @extend %sidebar-link-hover;
-
-      color: var(--site-title-color);
-    }
+    width: fit-content;
+    color: var(--site-title-color);
   }
 
   .site-subtitle {


### PR DESCRIPTION
## Type of change
- [x] Improvement (refactoring and improving code)

## Description
I would like to eliminate the use of `<h1>`for site title in the sidebar. Ref #1907 

## Additional context
I am having problems with search engines indexing blog posts. I would like to make the `<h1>` tag unique for post titles.
