### PR TITLE
fix: close popup gracefully with Esc key

### DIFF
--- a/_javascript/modules/components/toc/toc-mobile.js
+++ b/_javascript/modules/components/toc/toc-mobile.js
@@ -62,7 +62,11 @@ export class TocMobile {
     activeItem.scrollIntoView({ block: 'center' });
   }
 
-  static hidePopup() {
+  static hidePopup(event) {
+    if (event?.type === 'cancel') {
+      event.preventDefault();
+    }
+
     if (!$popup.open) {
       return;
     }


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
**Problem:** Closing a popup by pressing `Esc` is not handled correctly.

**Scenario:**
- Open blog post on mobile view
- Click `Contents`
- Close popup with `Esc` key

**Expected:** Popup is closed with animation.
**Actual/Problem:** Popup is closed without animation.

- Click `Contents` again

**Expected:** Popup can be opened again.
**Actual/Problem:** Popup is being closed on open (for the first time after closing). See recording attached.

<details>
<summary>Recording</summary>

![popup-esc](https://github.com/user-attachments/assets/42a853e6-497d-4ad7-933c-4a9f616bef86)
</details>

Ref #1964 