### PR TITLE
Allow overriding a post's HTML title by setting seo_title

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -52,9 +52,13 @@
 
   <title>
     {%- unless page.layout == 'home' -%}
-      {{ page.title | append: ' | ' }}
-    {%- endunless -%}
-    {{ site.title }}
+      {%- if post.seo_title -%}
+        {{ post.seo_title }}
+        {%- else -%}
+          {{ page.title | append: ' | ' }}
+        {%- endif -%}
+      {%- endunless -%}
+      {{ site.title }}
   </title>
 
   {% include_cached favicons.html %}


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->

For SEO it is important to be able to set an HTML title that is different than the post tile, as [explained in MSDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title#page_titles_and_seo)
