### PR TITLE
Improve workflow triggers

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,13 +2,12 @@ name: CD
 
 on:
   push:
-    branches:
-      - production
-    tags-ignore:
-      - "**"
+    branches: [production]
+    tags-ignore: ["**"]
 
 jobs:
   release:
+    if: ${{ ! startsWith(github.event.head_commit.message, 'chore(release)') }}
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches-ignore: [production]
+    branches:
+      - master
+      - "hotfix/*"
     paths-ignore:
       - ".github/**"
       - "!.github/workflows/ci.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,23 @@
-name: "CI"
+name: CI
 
 on:
   push:
-    branches:
-      - "master"
-      - "hotfix/**"
+    branches-ignore: [production]
     paths-ignore:
       - ".github/**"
       - "!.github/workflows/ci.yml"
-      - ".gitignore"
+      - .gitignore
       - "docs/**"
-      - "README.md"
-      - "LICENSE"
-  workflow_call:
+      - README.md
+      - LICENSE
+  pull_request:
+    paths-ignore:
+      - ".github/**"
+      - "!.github/workflows/ci.yml"
+      - .gitignore
+      - "docs/**"
+      - README.md
+      - LICENSE
 
 jobs:
   build:
@@ -44,7 +49,3 @@ jobs:
 
       - name: Test Site
         run: bash tools/test.sh
-
-  check-commit:
-    needs: build
-    uses: ./.github/workflows/commitlint.yml

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,6 +1,9 @@
 name: Lint Commit Messages
 
-on: workflow_call
+on:
+  push:
+    branches-ignore: [production]
+  pull_request:
 
 jobs:
   commitlint:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -2,7 +2,9 @@ name: Lint Commit Messages
 
 on:
   push:
-    branches-ignore: [production]
+    branches:
+      - master
+      - "hotfix/*"
   pull_request:
 
 jobs:

--- a/.github/workflows/pr-filter.yml
+++ b/.github/workflows/pr-filter.yml
@@ -19,15 +19,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          result-encoding: string
           script: |
             const script = require('.github/workflows/scripts/pr-filter.js');
-            return await script({ github, context });
-
-      - name: Abort due to invalid PR
-        if: ${{ steps.intercept.outputs.result != 'true' }}
-        run: exit 1
-
-  test:
-    needs: check-template
-    uses: ./.github/workflows/ci.yml
+            await script({ github, context, core });

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ on:
         required: true
       BUILDER:
         required: true
+  workflow_dispatch:
 
 jobs:
   launch:

--- a/.github/workflows/scripts/pr-filter.js
+++ b/.github/workflows/scripts/pr-filter.js
@@ -1,5 +1,5 @@
 function hasTypes(markdown) {
-  return /## Type of change/.test(markdown) && /-\s*\[x\]/i.test(markdown);
+  return /## Type of change/.test(markdown) && /-\s\[x\]/i.test(markdown);
 }
 
 function hasDescription(markdown) {
@@ -9,9 +9,9 @@ function hasDescription(markdown) {
   );
 }
 
-module.exports = async ({ github, context }) => {
+module.exports = async ({ github, context, core }) => {
   const pr = context.payload.pull_request;
-  const body = pr.body === null ? '' : pr.body.trim();
+  const body = pr.body === null ? '' : pr.body;
   const markdown = body.replace(/<!--[\s\S]*?-->/g, '');
   const action = context.payload.action;
 
@@ -31,7 +31,7 @@ module.exports = async ({ github, context }) => {
       issue_number: pr.number,
       body: `Oops, it seems you've ${action} an invalid pull request. No worries, we'll close it for you.`
     });
-  }
 
-  return isValid;
+    core.setFailed('PR content does not meet template requirements.');
+  }
 };

--- a/.github/workflows/style-lint.yml
+++ b/.github/workflows/style-lint.yml
@@ -1,8 +1,8 @@
-name: "Style Lint"
+name: Style Lint
 
 on:
   push:
-    branches: ["master", "hotfix/**"]
+    branches-ignore: [production]
     paths: ["_sass/**/*.scss"]
   pull_request:
     paths: ["_sass/**/*.scss"]

--- a/.github/workflows/style-lint.yml
+++ b/.github/workflows/style-lint.yml
@@ -2,7 +2,9 @@ name: Style Lint
 
 on:
   push:
-    branches-ignore: [production]
+    branches:
+      - master
+      - "hotfix/*"
     paths: ["_sass/**/*.scss"]
   pull_request:
     paths: ["_sass/**/*.scss"]


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Improvement (refactoring and improving code)


## Description

- Unchain commit-lint and CI
  - Even if a commit does not meet the CI path filter, it still needs to lint the commit message.
- Unchain PR filter and CI
  - The CI workflow needs to be triggered when the commits in a pull request are modified.
- Allow manual publishing
  - Sometimes `semantic-release` will error out due to commit messages referencing discussions, but this does not affect the final RubyGems/GitHub Release. In such cases, manual triggering of the publish process is needed to complete the remaining publishing steps.

