### PR TITLE
fix(gemfile): update wdm gem version for compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,4 @@ platforms :mingw, :x64_mingw, :mswin, :jruby do
   gem "tzinfo-data"
 end
 
-gem "wdm", ">= 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+gem "wdm", "~> 0.2.0", :platforms => [:mingw, :x64_mingw, :mswin]

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,4 @@ platforms :mingw, :x64_mingw, :mswin, :jruby do
   gem "tzinfo-data"
 end
 
-gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+gem "wdm", ">= 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
Below error occurred when running "bundle install" when using ruby 3.3.5, gem 3.5.22, gcc 14.2.0, GNU Make 4.4.1. 

"""
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
Installing wdm 0.1.1 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
.
.
.
creating Makefile

.
.
.
make: *** [Makefile:248: rb_monitor.o] Error 1

make failed, exit code 2

.
.
.

An error occurred while installing wdm (0.1.1), and Bundler cannot continue.

In Gemfile:
  wdm
"""

Fixed by installing wdm 0.2.0 using the proposed change to the gemfile.

## Additional context
A user will not able to run the server locally as described in the wiki when using the latest versions Ruby (v3.3.5), gem (v3.5.22), GCC (v14.2.0), and GNU Make (v4.4.1). This fix can make sure to avoid any more changes in the documentation.