### PR TITLE
Reduce unnecessary pr-filter runs

### DIFF
--- a/.github/workflows/pr-filter.yml
+++ b/.github/workflows/pr-filter.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   check-template:
+    if: github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/scripts/pr-filter.js
+++ b/.github/workflows/scripts/pr-filter.js
@@ -16,8 +16,7 @@ module.exports = async ({ github, context, core }) => {
   const action = context.payload.action;
 
   const isValid =
-    pr.labels.length > 0 || // PR create by Dependabot would have labels
-    (markdown !== '' && hasTypes(markdown) && hasDescription(markdown));
+    markdown !== '' && hasTypes(markdown) && hasDescription(markdown);
 
   if (!isValid) {
     await github.rest.pulls.update({


### PR DESCRIPTION

## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Improvement (refactoring and improving code)


## Description

- Checking the repository of the PR is more effective than checking the label to identify bot-initiated PRs
- This change also allows more flexible PR body definitions for developers with write access to the repository


## Additional context
N/A
