### PR TITLE
feat: support markdown inside details element

### DIFF
--- a/_plugins/details_tag.rb
+++ b/_plugins/details_tag.rb
@@ -1,0 +1,24 @@
+module Jekyll
+    module Tags
+      class DetailsTag < Liquid::Block
+  
+        def initialize(tag_name, markup, tokens)
+          super
+          @caption = markup
+        end
+  
+        def render(context)
+          site = context.registers[:site]
+          converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+          # below Jekyll 3.x use this:
+          # converter = site.getConverterImpl(::Jekyll::Converters::Markdown)
+          caption = converter.convert(@caption).gsub(/<\/?p[^>]*>/, '').chomp
+          body = converter.convert(super(context))
+          "<details><summary>#{caption}</summary>#{body}</details>"
+        end
+  
+      end
+    end
+  end
+  
+  Liquid::Template.register_tag('details', Jekyll::Tags::DetailsTag)


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
This PR is for issue #2046 which is regarding support for markdown content inside details elements. Currently detail tag content has to be written in html if formatting is required which is not ideal for markdown blogs.
The fix adds a plugin which adds a custom liquid tag `details` that can be used as so

```
{% details Read more about **something**... %}
  Now _I_ can write **markdown** here
  ### headings and [links](https://priyavkaneria.com) and everything else
{% enddetails %}
```

## Additional context
There might be some necessary documentation update under the post Text and Typography. I can make those changes if you want and this is is relevant.
The code for this plugin was inspired from [this](http://movb.de/jekyll-details-support.html) article