### PR TITLE
Allow images to be hidden from the top of posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -45,12 +45,15 @@ script_includes:
           {%- capture lqip -%}lqip="{{ page.image.lqip }}"{%- endcapture -%}
         {% endif %}
 
-        <div class="mt-3 mb-3">
-          <img {{ src }} {{ class }} {{ alt }} w="1200" h="630" {{ lqip }}>
-          {%- if page.image.alt -%}
-            <figcaption class="text-center pt-2 pb-2">{{ page.image.alt }}</figcaption>
-          {%- endif -%}
-        </div>
+        {% if page.image.show_image_in_post != false %}
+          <div class="mt-3 mb-3">
+            <img {{ src }} {{ class }} {{ alt }} w="1200" h="630" {{ lqip }}>
+            {%- if page.image.alt -%}
+              <figcaption class="text-center pt-2 pb-2">{{ page.image.alt }}</figcaption>
+            {%- endif -%}
+          </div>
+        {% endif %}
+
       {% endif %}
 
       <div class="d-flex justify-content-between">

--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -227,6 +227,7 @@ image:
 ```
 
 Note that the [`media_subpath`](#url-prefix) can also be passed to the preview image, that is, when it has been set, the attribute `path` only needs the image file name.
+Additionally, `image.show_image_in_post` can be added and set to `false` which will hide the image from being displayed at the top of the post. However, the image will still be displayed on the homepage next to the post and whenever sharing the post in social media. `image.show_image_in_post` is `true` by default.
 
 For simple use, you can also just use `image` to define the path.
 


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->
I was looking for a way to hide a post's image from the top of the post but still have it show on the home page and whenever it is shared in socials. This was mainly because I wanted the first part of the post to embed a corresponding YouTube video and I didn't want the post image and YouTube video to be displayed right next to each other, effectively showing the same things twice. 

I found [this discussion post](https://github.com/cotes2020/jekyll-theme-chirpy/discussions/1804) from someone else that is asking how to do this exact thing, and followed the suggestions there and made it into a PR.

## Additional context
<!-- e.g. Fixes #(issue) -->
This PR successfully hides the image from being shown at the top of the post.

- [ ] However, I'm unsure if this prevents the image from being shown when sharing via socials. It seems to be working via a "social share preview" browser extension but I'm not sure where `og:image` is being set, so please confirm that `og:image` is set correctly before merging.