### PR TITLE
fix: ensure pageviews are fetched after DOM is loaded

### DIFF
--- a/_includes/pageviews/goatcounter.html
+++ b/_includes/pageviews/goatcounter.html
@@ -1,12 +1,13 @@
 <!-- Display GoatCounter pageviews -->
 <script>
-  let pv = document.getElementById('pageviews');
+  document.addEventListener('DOMContentLoaded', () => {
+    const pv = document.getElementById('pageviews');
 
-  if (pv !== null) {
-    const uri = location.pathname.replace(/\/$/, '');
-    const url = `https://{{ site.analytics.goatcounter.id }}.goatcounter.com/counter/${encodeURIComponent(uri)}.json`;
+    if (pv !== null) {
+      const uri = location.pathname.replace(/\/$/, '');
+      const url = `https://{{ site.analytics.goatcounter.id }}.goatcounter.com/counter/${encodeURIComponent(uri)}.json`;
 
-    fetch(url)
+      fetch(url)
       .then((response) => response.json())
       .then((data) => {
         const count = data.count.replace(/\s/g, '');
@@ -15,5 +16,6 @@
       .catch((error) => {
         pv.innerText = '1';
       });
-  }
+    }
+  });
 </script>


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
The pageviews script is loaded inside the `<head>` and is therefore executed too early, causing pageviews to display an infinite spinner. In Chirpy 7.1.1 the script was loaded at the end of the `<body>`.

![image](https://github.com/user-attachments/assets/444c8440-ff3b-4a8c-99c9-b35fb2dc07c3)
