### PR TITLE
chore(ui): toggle sidebar icon on sidebar open

### DIFF
--- a/_javascript/modules/layouts/sidebar.js
+++ b/_javascript/modules/layouts/sidebar.js
@@ -1,6 +1,7 @@
 const ATTR_DISPLAY = 'sidebar-display';
 const $sidebar = document.getElementById('sidebar');
 const $trigger = document.getElementById('sidebar-trigger');
+const $icon = $trigger.querySelector('i');
 const $mask = document.getElementById('mask');
 
 class SidebarUtil {
@@ -10,6 +11,8 @@ class SidebarUtil {
     this.#isExpanded = !this.#isExpanded;
     document.body.toggleAttribute(ATTR_DISPLAY, this.#isExpanded);
     $sidebar.classList.toggle('z-2', this.#isExpanded);
+    $icon.classList.toggle('fa-bars', !this.#isExpanded);
+    $icon.classList.toggle('fa-close', this.#isExpanded);
     $mask.classList.toggle('d-none', !this.#isExpanded);
   }
 }


### PR DESCRIPTION
## Type of change
- [x] Improvement (refactoring and improving code)

## Description
Change the sidebar icon to 'close' when the sidebar is open to make the purpose of the button clear.
This is a nice to have improvement, as suggested in #2059.

![image](https://github.com/user-attachments/assets/ec76655c-f86e-4d99-a167-c1c3032ec7fd)
![image](https://github.com/user-attachments/assets/21fb3c3d-4cde-4dc9-a483-cb299a840b1e)
