### PR TITLE
Correct the js build watch path

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,10 +11,10 @@ const DIST = 'assets/js/dist';
 const banner = `/*!
  * ${pkg.name} v${pkg.version} | © ${pkg.since} ${pkg.author} | ${pkg.license} Licensed | ${pkg.homepage}
  */`;
-
 const frontmatter = `---\npermalink: /:basename\n---\n`;
-
 const isProd = process.env.BUILD === 'production';
+
+let hasWatched = false;
 
 function cleanup() {
   fs.rmSync(DIST, { recursive: true, force: true });
@@ -39,6 +39,11 @@ function build(
   { src = SRC_DEFAULT, jekyll = false, outputName = null } = {}
 ) {
   const input = `${src}/${filename}.js`;
+  const shouldWatch = hasWatched ? false : true;
+
+  if (!hasWatched) {
+    hasWatched = true;
+  }
 
   return {
     input,
@@ -49,9 +54,7 @@ function build(
       banner,
       sourcemap: !isProd && !jekyll
     },
-    watch: {
-      include: input
-    },
+    ...(shouldWatch && { watch: { include: `${SRC_DEFAULT}/**/*.js` } }),
     plugins: [
       babel({
         babelHelpers: 'bundled',


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (refactoring and improving code)


## Description

1. Correct the rollup watch path
2. Avoid registering watch listeners redundantly across multiple tasks


## Additional context
<!-- e.g. Fixes #(issue) -->
N/A
