### PR TITLE
fix: always load theme script

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -99,9 +99,7 @@
 
   <!-- Scripts -->
 
-  {% unless site.theme_mode %}
-    <script src="{{ '/assets/js/dist/theme.min.js' | relative_url }}"></script>
-  {% endunless %}
+  <script src="{{ '/assets/js/dist/theme.min.js' | relative_url }}"></script>
 
   {% include js-selector.html lang=lang %}
 


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
When theme is forcibly set, the theme script is excluded, which causes multiple problems. Fixes #2066 