### PR TITLE
fix: refreshing theme will not crash diagrams any longer

### DIFF
--- a/_data/locales/nl-NL.yml
+++ b/_data/locales/nl-NL.yml
@@ -1,0 +1,90 @@
+# The layout text of site
+
+# ----- Commons label -----
+
+layout:
+  post: Post
+  category: Categorie
+  tag: Tag
+
+# The tabs of sidebar
+tabs:
+  # format: <filename_without_extension>: <value>
+  home: Startpagina
+  categories: Categorieën
+  tags: Tags
+  archives: Archief
+  about: Over
+
+# the text displayed in the search bar & search results
+search:
+  hint: Zoek
+  cancel: Annuleer
+  no_results: Oops! Geen resultaat gevonden.
+
+panel:
+  lastmod: Recent Bijgewerkt
+  trending_tags: Trending Tags
+  toc: Inhoud
+
+copyright:
+  # Shown at the bottom of the post
+  license:
+    template: Alle posts zijn onder :LICENSE_NAME gepubliceerd door de auteur.
+    name: CC BY 4.0
+    link: https://creativecommons.org/licenses/by/4.0/
+
+  # Displayed in the footer
+  brief: Sommige rechten voorbehouden.
+  verbose: >-
+    Tenzij anders vermeld, alle posts zijn onder de
+    Creative Commons Attribution 4.0 International (CC BY 4.0) gepubliceerd door de auteur.
+
+meta: Gebruikt :THEME
+
+not_found:
+  statement: Sorry, we hebben de URL verkeerd geplaatst of hij verwijst naar iets dat niet bestaat.
+
+notification:
+  update_found: Nieuwe versie van inhoud beschikbaar.
+  update: Update
+
+# ----- Posts related labels -----
+post:
+  written_by: Door
+  posted: Posted
+  updated: Bijgewerkt
+  words: woorden
+  pageview_measure: Gelezen
+  read_time:
+    unit: min
+    prompt: lees
+  relate_posts: Verder Lezen
+  share: Deel
+  button:
+    next: Volgende
+    previous: Vorige
+    copy_code:
+      succeed: Gekopieerd!
+    share_link:
+      title: Link kopiëren
+      succeed: Succesvol gekopieerd!
+
+# Date time format.
+# See: <http://strftime.net/>, <https://day.js.org/docs/en/display/format>
+df:
+  post:
+    strftime: "%b %e, %Y"
+    dayjs: "ll"
+  archives:
+    strftime: "%b"
+    dayjs: "MMM"
+
+# categories page
+categories:
+  category_measure:
+    singular: categorie
+    plural: categorieën
+  post_measure:
+    singular: post
+    plural: posts

--- a/_javascript/modules/components/mermaid.js
+++ b/_javascript/modules/components/mermaid.js
@@ -12,7 +12,7 @@ function refreshTheme(event) {
 
     [...mermaidList].forEach((elem) => {
       const svgCode = elem.previousSibling.children.item(0).innerHTML;
-      elem.textContent = svgCode;
+      elem.innerHTML = svgCode;
       elem.removeAttribute('data-processed');
     });
 


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->

found wrong target to place backed-up diagram snippets and corrected it.

## Additional context
<!-- e.g. Fixes #(issue) -->

Fixes #2107
