### PR TITLE
Adjust the gap between TOC entries

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -3,7 +3,7 @@
 {% if enable_toc %}
   <div class="toc-border-cover z-3"></div>
   <section id="toc-wrapper" class="invisible position-sticky ps-0 pe-4 pb-4">
-    <h2 class="panel-heading ps-3 pb-2 mb-0">{{- site.data.locales[include.lang].panel.toc -}}</h2>
+    <h2 class="panel-heading ps-3 pb-1 mb-0">{{- site.data.locales[include.lang].panel.toc -}}</h2>
     <nav id="toc"></nav>
   </section>
 {% endif %}

--- a/_sass/pages/_post.scss
+++ b/_sass/pages/_post.scss
@@ -275,10 +275,6 @@ header {
         margin: 0.4rem 0;
       }
 
-      &:first-child {
-        margin-top: 0;
-      }
-
       a {
         padding: 0.2rem 0 0.2rem 1.25rem;
       }


### PR DESCRIPTION


## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Description

Fix on UI: In desktop mode, H2 and the first sub-level H3 in the TOC are too close.
