### PR TITLE
Keep TOC fade up in desktop mode

### DIFF
--- a/_sass/pages/_post.scss
+++ b/_sass/pages/_post.scss
@@ -220,14 +220,11 @@ header {
 @-webkit-keyframes fade-up {
   from {
     opacity: 0;
-    position: relative;
-    top: 2rem;
+    margin-top: 4rem;
   }
 
   to {
     opacity: 1;
-    position: relative;
-    top: 0;
   }
 }
 
@@ -247,6 +244,7 @@ header {
 %top-cover {
   content: '';
   display: block;
+  position: -webkit-sticky;
   position: sticky;
   top: 0;
   width: 100%;
@@ -257,12 +255,15 @@ header {
 #toc-wrapper {
   top: 0;
   transition: top 0.2s ease-in-out;
-  -webkit-animation: fade-up 0.8s;
-  animation: fade-up 0.8s;
   overflow-y: auto;
   max-height: 100vh;
   scrollbar-width: none;
   margin-top: 2rem;
+
+  &:not(.invisible) {
+    -webkit-animation: fade-up 0.8s;
+    animation: fade-up 0.8s;
+  }
 
   ul {
     list-style: none;


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

In desktop mode, the randomness of the script execution order in the browser may cause the fade-up animation of the TOC to be lost.


https://github.com/user-attachments/assets/291c9fdc-cdca-491f-b9b0-dcc619c77af1

