### PR TITLE
Remove the `aspect-ratio` directive from `.embed-video` CSS class

### DIFF
--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -291,7 +291,6 @@ main {
   width: 100%;
   height: 100%;
   margin-bottom: 1rem;
-  aspect-ratio: 16 / 9;
 
   @extend %rounded;
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Not all video is in 16:9 aspect ratio (e.g., vertical video), and forcing that causes the videos to appear small with large black spaces on either side.

