### PR TITLE
fix(ui): left borderline of TOC is notched

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -3,7 +3,7 @@
 {% if enable_toc %}
   <div class="toc-border-cover z-3"></div>
   <section id="toc-wrapper" class="invisible position-sticky ps-0 pe-4 pb-4">
-    <h2 class="panel-heading ps-3 pb-1 mb-0">{{- site.data.locales[include.lang].panel.toc -}}</h2>
+    <h2 class="panel-heading ps-3 pb-2 mb-0">{{- site.data.locales[include.lang].panel.toc -}}</h2>
     <nav id="toc"></nav>
   </section>
 {% endif %}

--- a/_sass/pages/_post.scss
+++ b/_sass/pages/_post.scss
@@ -272,12 +272,8 @@ header {
     padding-left: 0;
 
     li {
-      &:not(:last-child) {
-        margin: 0.4rem 0;
-      }
-
       a {
-        padding: 0.2rem 0 0.2rem 1.25rem;
+        padding: 0.4rem 0 0.4rem 1.25rem;
       }
     }
 


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Description

UI fixes: 

<img width="314" alt="Screenshot 2024-12-22 at 03 04 47" src="https://github.com/user-attachments/assets/9ed58598-84dc-4d14-9e58-1866e460559a" />


