### PR TITLE
🐛 Fix deployment workflow issue

### DIFF
--- a/.github/workflows/starter/pages-deploy.yml
+++ b/.github/workflows/starter/pages-deploy.yml
@@ -46,7 +46,7 @@ jobs:
           bundler-cache: true
 
       - name: Build site
-        run: bundle exec jekyll b -d "_site${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll b -d "_site"
         env:
           JEKYLL_ENV: "production"
 
@@ -59,7 +59,7 @@ jobs:
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: "_site${{ steps.pages.outputs.base_path }}"
+          path: "_site"
 
   deploy:
     environment:


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Environment 
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux-gnu]
jekyll 4.3.4
jekyll-theme-chirpy (7.2.4)

## Description
When pushing to Github, Github Workflow "pages-deploy.yml" starts and then the steps "Test site" and "Upload site artifact" are failing

![image](https://github.com/user-attachments/assets/2fab7020-7dd6-4820-9260-ca73885b216c)

with the following error at the end of the log : 

```
HTML-Proofer found 324 failures!
Error: Process completed with exit code 1.
```

## Additional context
I have seen several people commenting out this part which I think doesn't really resolve the source problem.