### PR TITLE
Add more files into the jekyll-theme-chirpy RubyGems.org

### DIFF
--- a/jekyll-theme-chirpy.gemspec
+++ b/jekyll-theme-chirpy.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f|
-    f.match(%r!^((_(includes|layouts|sass|(data\/(locales|origin)))|assets)\/|README|LICENSE)!i)
+    f.match(%r!^((_(includes|layouts|sass|config|plugins|tabs(data\/(locales|origin)))|assets)\/|README|LICENSE|index)!i)
   }
 
   spec.metadata = {


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
At your [chirpy-starter](https://github.com/cotes2020/chirpy-starter?tab=readme-ov-file#chirpy-starter), I read that the jekyll-theme-chirpy gem from RubyGems is missing some important files to provide additional features out of the box

I might be mistaken, but I believe that by adding this change, the gem will include the desired folders in the bundled gem.

> You can test this by running the [gem build](https://guides.rubygems.org/make-your-own-gem/) command and inspect the generated gem.
> I can do it for you but might take some time

## Additional context

I read it here: https://github.com/cotes2020/chirpy-starter?tab=readme-ov-file#chirpy-starter
