### PR TITLE
Add Persian Language Support to Jekyll-Theme-Chirpy

### DIFF
--- a/_data/locales/fa-IR.yaml
+++ b/_data/locales/fa-IR.yaml
@@ -1,0 +1,91 @@
+# The layout text of site
+
+# ----- Commons label -----
+
+layout:
+  post: پست
+  category: دسته‌بندی
+  tag: برچسب
+
+# The tabs of sidebar
+tabs:
+  # format: <filename_without_extension>: <value>
+  home: خانه
+  categories: دسته‌بندی‌ها
+  tags: برچسب‌ها
+  archives: آرشیو
+  about: درباره
+
+# the text displayed in the search bar & search results
+search:
+  hint: جستجو
+  cancel: لغو
+  no_results: متأسفیم! هیچ نتیجه‌ای یافت نشد.
+
+panel:
+  lastmod: آخرین به‌روزرسانی
+  trending_tags: برچسب‌های پرطرفدار
+  toc: فهرست مطالب
+
+copyright:
+  # Shown at the bottom of the post
+  license:
+    template: این پست تحت مجوز :LICENSE_NAME توسط نویسنده منتشر شده است.
+    name: CC BY 4.0
+    link: https://creativecommons.org/licenses/by/4.0/
+
+  # Displayed in the footer
+  brief: برخی حقوق محفوظ است.
+  verbose: >-
+    مگر اینکه خلاف آن ذکر شده باشد، پست‌های وبلاگ در این سایت
+    تحت مجوز Creative Commons Attribution 4.0 International (CC BY 4.0) توسط نویسنده منتشر شده‌اند.
+
+meta: با استفاده از :PLATFORM قالب :THEME
+
+not_found:
+  statement: متأسفیم، لینک زیر معتبر نیست یا به صفحه‌ای که وجود ندارد اشاره می‌کند.
+
+notification:
+  update_found: نسخه جدیدی از محتوا موجود است.
+  update: به‌روزرسانی
+
+# ----- Posts related labels -----
+
+post:
+  written_by: نوشته شده توسط
+  posted: منتشر شده
+  updated: به‌روزرسانی شده
+  words: کلمات
+  pageview_measure: بازدیدها
+  read_time:
+    unit: دقیقه
+    prompt: زمان مطالعه
+  relate_posts: بیشتر بخوانید
+  share: اشتراک‌گذاری
+  button:
+    next: جدیدتر
+    previous: قدیمی‌تر
+    copy_code:
+      succeed: کپی شد!
+    share_link:
+      title: کپی لینک
+      succeed: لینک با موفقیت کپی شد!
+
+# Date time format.
+# See: <http://strftime.net/>, <https://day.js.org/docs/en/display/format>
+df:
+  post:
+    strftime: "%b %e, %Y"
+    dayjs: "ll"
+  archives:
+    strftime: "%b"
+    dayjs: "MMM"
+
+# categories page
+categories:
+  category_measure:
+    singular: دسته‌بندی
+    plural: دسته‌بندی‌ها
+  post_measure:
+    singular: پست
+    plural: پست‌ها


### PR DESCRIPTION
# Add Persian Language Support to Jekyll-Theme-Chirpy

## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->
This PR adds Persian (Farsi) language support to the `jekyll-theme-chirpy`. The translation includes:
- Common labels (e.g., posts, categories, tags)
- Sidebar tabs (e.g., home, categories, tags, archives, about)
- Search bar and results text
- Panel labels (e.g., last modified, trending tags, table of contents)
- Copyright and license information
- Meta descriptions
- 404 error page text
- Post-related labels (e.g., written by, posted, updated, words, page views, read time, share buttons)
- Date and time formats
- Categories page labels

The translation ensures that Persian-speaking users can navigate and interact with the theme seamlessly.

## Additional context
<!-- e.g. Fixes #(issue) -->
This addition does not introduce any breaking changes and is fully compatible with existing functionality. The Persian language can be activated by setting the `lang` parameter in the site configuration to `fa` or `fa-IR`.