### PR TITLE
Graph tab

### DIFF
--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -52,7 +52,7 @@
 {% include jsdelivr-combine.html urls=urls %}
 
 {% case page.layout %}
-  {% when 'home', 'categories', 'post', 'page' %}
+  {% when 'home', 'categories', 'post', 'page', 'graph' %}
     {% assign js = page.layout %}
   {% when 'archives', 'category', 'tag' %}
     {% assign js = 'misc' %}

--- a/_javascript/graph.js
+++ b/_javascript/graph.js
@@ -1,0 +1,8 @@
+import { basic, initSidebar, initTopbar } from './modules/layouts';
+import { graphInit } from './modules/components/graph-visualization';
+
+initSidebar();
+initTopbar();
+basic();
+
+graphInit();

--- a/_javascript/modules/components/graph-visualization.js
+++ b/_javascript/modules/components/graph-visualization.js
@@ -1,0 +1,204 @@
+import { select, zoom, drag, forceSimulation, forceLink, forceManyBody, forceCenter, zoomIdentity } from "d3";
+
+const d3 = {
+  select,
+  zoom,
+  drag,
+  forceSimulation,
+  forceLink,
+  forceManyBody,
+  forceCenter,
+  zoomIdentity
+};
+
+const nodes = [];
+const links = [];
+const tags = new Set();  // To track unique tags
+
+// Fetch the JSON graph data
+function loadGraphData() {
+    fetch("/assets/js/data/graph.json")
+    .then(response => response.json())
+    .then(data => {
+        data.forEach(post => {
+        nodes.push({ id: post.id, type: 'post', url: post.url });
+        post.tags.forEach(tag => {
+            if (!tags.has(tag)) {
+            nodes.push({ id: tag, type: 'tag' });
+            tags.add(tag);  // Add the tag to the set to avoid duplicates
+            }
+            links.push({ source: post.id, target: tag, label: tag });
+        });
+        });
+        initializeGraph();  // Initialize the graph after the data is fetched
+    })
+    .catch(error => console.error("Error loading JSON:", error));
+}
+
+// Initialize the graph (D3 code)
+function initializeGraph() {
+  // Set up SVG and simulation
+  const svg = d3.select("svg");
+  const width = svg.node().getBoundingClientRect().width;
+  const height = svg.node().getBoundingClientRect().height;
+
+  const zoomBehavior = d3.zoom()
+    .scaleExtent([0.3, 5]) // Set zoom-out and zoom-in limits
+    .on("zoom", (event) => {
+      container.attr("transform", event.transform); // Apply zoom transform
+    });
+
+  svg.call(zoomBehavior);
+
+  const container = svg.append("g");
+
+  // Create a force simulation to position the nodes
+  const simulation = d3.forceSimulation(nodes)
+    .force("link", d3.forceLink(links).id(d => d.id).distance(100))
+    .force("charge", d3.forceManyBody().strength(-200))
+    .force("center", d3.forceCenter(width / 2, height / 2));  // Center the graph initially
+
+  // Create link elements
+  const link = container.append("g")
+    .attr("class", "links")
+    .selectAll("line")
+    .data(links)
+    .enter().append("line")
+    .attr("class", "link");
+
+  // Create node elements
+  const node = container.append("g")
+  .attr("class", "nodes")
+  .selectAll("circle")
+  .data(nodes)
+  .enter().append("circle")
+  .attr("class", d => d.type === 'post' ? "post-node" : "tag-node")
+  .attr("r", d => d.type === 'post' ? 8 : 4)
+  .call(d3.drag()
+          .on("start", dragstarted)
+          .on("drag", dragged)
+          .on("end", dragended))
+  .on("click", (event, d) => {
+    if (d.type === 'post' && d.url) {
+      window.location.href = d.url;  // Redirect to the post URL
+    }if (d.type === 'tag') {
+      window.location.href = generateTagUrl(d.id);
+    } 
+  });
+
+  // Add text labels for tag nodes
+  const labels = container.append("g")
+    .attr("class", "node-labels")
+    .selectAll("text")
+    .data(nodes)
+    .enter().append("text")
+    .attr("class", d => d.type === 'post' ? "post-label" : "tag-label")
+    .attr("dy", "-10px") // Position the label above the node
+    .text(d => d.id);
+
+  // Update positions on each simulation tick
+  simulation.on("tick", () => {
+    link
+      .attr("x1", d => d.source.x)
+      .attr("y1", d => d.source.y)
+      .attr("x2", d => d.target.x)
+      .attr("y2", d => d.target.y);
+    
+    node
+      .attr("cx", d => d.x)
+      .attr("cy", d => d.y);
+    
+    labels
+      .attr("x", d => d.x)
+      .attr("y", d => d.y);
+  });
+
+  // Drag event handlers
+  function dragstarted(event, d) {
+    if (!event.active) simulation.alphaTarget(0.3).restart();
+    d.fx = d.x;
+    d.fy = d.y;
+  }
+
+  function dragged(event, d) {
+    d.fx = event.x;
+    d.fy = event.y;
+  }
+
+  function dragended(event, d) {
+    if (!event.active) simulation.alphaTarget(0);
+    d.fx = null;
+    d.fy = null;
+  }
+
+  // Update the fitGraphToContainer function to accept new dimensions
+  function fitGraphToContainer(width, height) {
+    const bounds = container.node().getBBox();
+    const w = bounds.width;
+    const h = bounds.height;
+    const midX = bounds.x + w / 2;
+    const midY = bounds.y + h / 2;
+
+    if (w === 0 || h === 0) return; // Avoid division by zero
+
+    // Calculate scale to fit the graph into view
+    const scale = 0.9 / Math.max(w / width, h / height);
+    const transform = d3.zoomIdentity
+      .translate(width / 2 - scale * midX, height / 2 - scale * midY)
+      .scale(scale);
+
+    svg.transition().duration(500).call(zoomBehavior.transform, transform);
+  }
+
+  // Run the fit function once the simulation settles
+  simulation.on("end", () => {
+    fitGraphToContainer(width, height);
+  });
+
+  // Recenter the graph in smaller screens
+  window.addEventListener('resize', () => {
+    const newWidth = svg.node().getBoundingClientRect().width;
+    const newHeight = svg.node().getBoundingClientRect().height;
+    
+    // Update the force simulation center to the new size
+    simulation.force('center', d3.forceCenter(newWidth / 2, newHeight / 2));
+
+    // Adjust zoom settings after resize
+    svg.transition().duration(500).call(zoomBehavior.transform, zoomIdentity.translate(newWidth / 2, newHeight / 2).scale(1));
+    
+    // Fit the graph to the new size
+    fitGraphToContainer(newWidth, newHeight);
+  });
+
+  // Ensure touch events for drag work on mobile devices
+  svg.on("touchstart", function(event) {
+    event.preventDefault(); // Prevent default to avoid zoom issues
+  });
+}
+
+// Sluggify function
+function slugify(str) {
+  return str
+    .toString()
+    .toLowerCase()
+    .normalize("NFD") // Remove accents
+    .replace(/[\u0300-\u036f]/g, "") // Remove diacritics
+    .replace(/[^a-z0-9 -]/g, '') // Remove invalid characters
+    .replace(/\s+/g, '-') // Replace spaces with hyphens
+    .replace(/-+/g, '-'); // Replace multiple hyphens with a single hyphen
+}
+
+// URL encode function
+function urlEncode(str) {
+  return encodeURIComponent(str);
+}
+
+// Process the tag (slugify, URL encode, and build the final URL)
+function generateTagUrl(tag) {
+  const sluggedTag = slugify(tag);
+  const encodedTag = urlEncode(sluggedTag);
+  const url = `/tags/${encodedTag}/`; // Prepend and append paths
+  return url;
+}
+
+export { loadGraphData as graphInit };

--- a/_layouts/graph.html
+++ b/_layouts/graph.html
@@ -1,0 +1,8 @@
+---
+layout: page
+# A graph of posts and tags
+---
+
+<div class="graph-container d-flex flex-wrap mx-xl-2">
+  <svg id="graph-svg" style="width: 100%; height: 100%;"></svg>
+</div>

--- a/_posts/2019-08-08-text-and-typography.md
+++ b/_posts/2019-08-08-text-and-typography.md
@@ -4,7 +4,7 @@ description: Examples of text, typography, math equations, diagrams, flowcharts,
 author: cotes
 date: 2019-08-08 11:33:00 +0800
 categories: [Blogging, Demo]
-tags: [typography]
+tags: [typography, chirpy]
 pin: true
 math: true
 mermaid: true

--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -3,7 +3,7 @@ title: Writing a New Post
 author: cotes
 date: 2019-08-08 14:10:00 +0800
 categories: [Blogging, Tutorial]
-tags: [writing]
+tags: [writing, chirpy, tutorial]
 render_with_liquid: false
 ---
 

--- a/_posts/2019-08-09-getting-started.md
+++ b/_posts/2019-08-09-getting-started.md
@@ -6,7 +6,7 @@ description: >-
 author: cotes
 date: 2019-08-09 20:55:00 +0800
 categories: [Blogging, Tutorial]
-tags: [getting started]
+tags: [getting started, chirpy, showcase]
 pin: true
 media_subpath: '/posts/20180809'
 ---

--- a/_posts/2019-08-11-customize-the-favicon.md
+++ b/_posts/2019-08-11-customize-the-favicon.md
@@ -3,7 +3,7 @@ title: Customize the Favicon
 author: cotes
 date: 2019-08-11 00:34:00 +0800
 categories: [Blogging, Tutorial]
-tags: [favicon]
+tags: [favicon, chirpy, tutorial]
 ---
 
 The [favicons](https://www.favicon-generator.org/about/) of [**Chirpy**](https://github.com/cotes2020/jekyll-theme-chirpy/) are placed in the directory `assets/img/favicons/`{: .filepath}. You may want to replace them with your own. The following sections will guide you to create and replace the default favicons.

--- a/_sass/pages/_graph.scss
+++ b/_sass/pages/_graph.scss
@@ -1,0 +1,51 @@
+.graph-container {
+    width: 100%;
+    height: 80vh;
+    display: flex;
+    justify-content: center;
+    position: relative;
+    border-radius: 0.7em;
+    border: 1px solid var(--graph-border) !important;
+    overflow: hidden;
+    align-items: center;
+}
+
+.post-node {
+    r: 10;
+    fill: var(--graph-post-node-color);
+    stroke: var(--graph-post-node-stroke-color);
+    stroke-width: 1.5px;
+}
+
+.post-node:hover {
+    fill: var(--graph-post-node-hover-color);
+    stroke: var(--graph-post-node-hover-stroke-color);
+}
+
+.tag-node {
+    fill: var(--graph-tag-node-color);
+    stroke: var(--graph-tag-node-stroke-color);
+    stroke-width: 1.5px;
+}
+
+.tag-node:hover {
+    fill: var(--graph-tag-node-hover-color);
+    stroke: var(--graph-tag-node-hover-stroke-color);
+}
+
+.post-label {
+    text-anchor: middle;
+    font-size: 12px;
+    fill: var(--text-color);
+}
+  
+.tag-label {
+    text-anchor: middle;
+    font-size: 12px;
+    fill: var(--text-color);
+}
+
+.link {
+    stroke: var(--graph-edges-color);
+    stroke-opacity: 0.5;
+}

--- a/_sass/pages/_index.scss
+++ b/_sass/pages/_index.scss
@@ -5,3 +5,4 @@
 @forward 'tags';
 @forward 'archives';
 @forward 'category-tag';
+@forward 'graph';

--- a/_sass/themes/_dark.scss
+++ b/_sass/themes/_dark.scss
@@ -88,6 +88,21 @@
   --dash-color: rgb(63, 65, 68);
   --search-tag-bg: #292828;
 
+  /* Graph */
+  --graph-border: #3B4F58;
+  --graph-tag-node-color: #f8f9fa;
+  --graph-post-node-color: #8AB4F8;
+  --graph-tag-node-hover-color: #dee2e6;
+  --graph-post-node-hover-color: #0d6efd;
+  --graph-edges-color: #0056b2;
+  --graph-edges-hover-color: #004085;
+  --graph-tag-node-stroke-color: var(--main-bg);
+  --graph-post-node-stroke-color: var(--main-bg);
+  --graph-tag-node-stroke-hover-color: var(--tag-node-hover-color);
+  --graph-post-node-stroke-hover-color: var(--post-node-hover-color);
+  --graph-tag-label-color: #585858;
+  --graph-post-label-color: #34343c;
+
   /* Categories */
   --categories-border: rgb(64, 66, 69, 0.5);
   --categories-hover-bg: rgb(73, 75, 76);

--- a/_sass/themes/_light.scss
+++ b/_sass/themes/_light.scss
@@ -88,6 +88,23 @@
   --tag-hover: rgb(222, 226, 230);
   --search-tag-bg: #f8f9fa;
 
+  /* Graph */
+  --graph-border: #dee2e6;
+  --graph-tag-node-color: #f8f9fa;
+  --graph-post-node-color: #0056b2;
+  --graph-tag-node-hover-color: #dee2e6;
+  --graph-post-node-hover-color: #0d6efd;
+  --graph-edges-color: #dee2e6;
+  --graph-edges-hover-color: #004085;
+  --graph-tag-node-stroke-color: #dee2e6;
+  --graph-post-node-stroke-color: var(--main-bg);
+  --graph-tag-node-stroke-hover-color: var(--tag-node-hover-color);
+  --graph-post-node-stroke-hover-color: var(--post-node-hover-color);
+  --graph-tag-label-color: #585858;
+  --graph-post-label-color: #34343c;
+  
+
+
   /* Categories */
   --categories-border: rgba(0, 0, 0, 0.125);
   --categories-hover-bg: var(--btn-border-color);

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -1,7 +1,7 @@
 ---
 # the default layout is 'page'
 icon: fas fa-info-circle
-order: 4
+order: 5
 ---
 
 > Add Markdown syntax content to file `_tabs/about.md`{: .filepath } and it will show up on this page.

--- a/_tabs/archives.md
+++ b/_tabs/archives.md
@@ -1,5 +1,5 @@
 ---
 layout: archives
 icon: fas fa-archive
-order: 3
+order: 4
 ---

--- a/_tabs/graph.md
+++ b/_tabs/graph.md
@@ -1,0 +1,6 @@
+---
+title: Graph
+icon: fas fa-hexagon-nodes
+layout: graph
+order: 3
+---

--- a/assets/js/data/graph.json
+++ b/assets/js/data/graph.json
@@ -1,0 +1,14 @@
+---
+layout: compress
+swcache: true
+---
+
+[
+  {% for post in site.posts %}
+    {
+      "id": {{ post.title | jsonify }},
+      "tags": {{ post.tags | jsonify }},
+      "url": {{ post.url | relative_url | jsonify }}
+    }{% unless forloop.last %},{% endunless %}
+  {% endfor %}
+]

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
-    "bootstrap": "^5.3.3"
+    "bootstrap": "^5.3.3",
+    "d3": "^7.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -77,6 +77,7 @@ export default [
   build('commons'),
   build('home'),
   build('categories'),
+  build('graph'),
   build('page'),
   build('post'),
   build('misc'),


### PR DESCRIPTION
## Type of change

- [x] New feature (non-breaking change which adds functionality)
expected)

## Description

This PR implements a **Graph View** tab in the theme, visualizing relationships between **tags and posts**. This enhancement is based on issue #1953 and provides an intuitive way to explore connections between content.

### Key Changes:

- Added a new **Graph View** tab to the theme.
- Uses [D3.js](https://d3js.org/) to dynamically generate the graph.
- Displays posts as nodes and tags as linked nodes.
- You can interact with the graph for better visualization.
- Added new `tags` to existing posts to better showcase the graph.

## Additional context
This feature enhances content discoverability and provides a visual representation of post relationships.

Fixes: #1953
### 📸 Screenshot
![image](https://github.com/user-attachments/assets/ff570ba5-141b-4e44-b9c4-68ded02660ba)

Let me know if you have any suggestions! 🚀 I'll keep refining it over time.