### PR TITLE
feat: github alert syntax

### DIFF
--- a/_includes/refactor-content.html
+++ b/_includes/refactor-content.html
@@ -251,5 +251,33 @@
 
 {% assign _content = _heading_content %}
 
+<!-- Handle blockquote with prompts -->
+{% if _content contains '<blockquote>' %}
+  {% assign _blockquote_snippets = _content | split: '<blockquote>' %}
+  {% assign _new_content = _blockquote_snippets.first %}
+
+  {% for _snippet in _blockquote_snippets %}
+    {% unless forloop.first %}
+      {% if _snippet contains '<p>[!NOTE]' or _snippet contains '<p>[!note]' %}
+        {% assign _note_content = _snippet | replace_first: '<p>[!NOTE]', '<p>' | replace_first: '<p>[!note]', '<p>' | replace_first: '<p></p>', '' %}
+        {% assign _new_content = _new_content | append: '<blockquote class="prompt-info">' | append: _note_content %}
+      {% elsif _snippet contains '<p>[!TIP]' or _snippet contains '<p>[!tip]' %}
+        {% assign _note_content = _snippet | replace_first: '<p>[!TIP]', '<p>' | replace_first: '<p>[!tip]', '<p>' | replace_first: '<p></p>', '' %}
+        {% assign _new_content = _new_content | append: '<blockquote class="prompt-tip">' | append: _note_content %}
+      {% elsif _snippet contains '<p>[!WARNING]' or _snippet contains '<p>[!warning]' %}
+        {% assign _note_content = _snippet | replace_first: '<p>[!WARNING]', '<p>' | replace_first: '<p>[!warning]', '<p>' | replace_first: '<p></p>', '' %}
+        {% assign _new_content = _new_content | append: '<blockquote class="prompt-warning">' | append: _note_content %}
+      {% elsif _snippet contains '<p>[!CAUTION]' or _snippet contains '<p>[!caution]' %}
+        {% assign _note_content = _snippet | replace_first: '<p>[!CAUTION]', '<p>' | replace_first: '<p>[!caution]', '<p>' | replace_first: '<p></p>', '' %}
+        {% assign _new_content = _new_content | append: '<blockquote class="prompt-danger">' | append: _note_content %}
+      {% else %}
+        {% assign _new_content = _new_content | append: '<blockquote>' | append: _snippet %}
+      {% endif %}
+    {% endunless %}
+  {% endfor %}
+
+  {% assign _content = _new_content %}
+{% endif %}
+
 <!-- return -->
 {{ _content }}

--- a/_posts/2019-08-08-text-and-typography.md
+++ b/_posts/2019-08-08-text-and-typography.md
@@ -83,6 +83,20 @@ Moon
 
 > An example showing the `danger` type prompt.
 {: .prompt-danger }
+
+> [!TIP] Github `tip` block.
+
+> [!NOTE]
+> Github `note` block.
+
+> [!WARNING]
+>
+> Github `warning` block.
+
+> [!CAUTION]
+>
+> 
+> Github `caution` block.
 <!-- markdownlint-restore -->
 
 ## Tables


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->

Add support for github alert syntax, which is fully compatible with the origin prompt syntax and reuse the css style of prompt.

As for the `[!IMPORTANT]` type, imo there's no need to have one, the existing types are enough for prompting.

## Additional context
<!-- e.g. Fixes #(issue) -->
https://github.com/cotes2020/jekyll-theme-chirpy/issues/2144
