### PR TITLE
Beautify the three dots of the markdown code block with different colors

### DIFF
--- a/_sass/base/_syntax.scss
+++ b/_sass/base/_syntax.scss
@@ -137,11 +137,11 @@ div[class^='language-'] {
         width: v.$code-dot-size;
         height: v.$code-dot-size;
         border-radius: 50%;
-        background-color: var(--code-header-muted-color);
+        background-color: var(--code-header-first-muted-color);
         box-shadow: (v.$code-dot-size + v.$code-dot-gap) 0 0
-            var(--code-header-muted-color),
+            var(--code-header-second-muted-color),
           (v.$code-dot-size + v.$code-dot-gap) * 2 0 0
-            var(--code-header-muted-color);
+            var(--code-header-third-muted-color);
       }
 
       span {

--- a/_sass/themes/_dark.scss
+++ b/_sass/themes/_dark.scss
@@ -106,7 +106,10 @@
   --inline-code-bg: rgba(255, 255, 255, 0.05);
   --code-color: #b0b0b0;
   --code-header-text-color: #6a6a6a;
-  --code-header-muted-color: #353535;
+  --code-header-muted-color: #353535; /* unused */
+  --code-header-first-muted-color: rgb(250, 66, 66);
+  --code-header-second-muted-color: rgb(255, 165, 0);
+  --code-header-third-muted-color: rgb(2, 184, 2);
   --code-header-icon-color: #565656;
   --clipboard-checked-color: #2bcc2b;
   --filepath-text-color: #cacaca;

--- a/_sass/themes/_light.scss
+++ b/_sass/themes/_light.scss
@@ -106,7 +106,10 @@
   --inline-code-bg: rgba(25, 25, 28, 0.05);
   --code-color: #3a3a3a;
   --code-header-text-color: #a3a3a3;
-  --code-header-muted-color: #e5e5e5;
+  --code-header-muted-color: #e5e5e5; /* unused */
+  --code-header-first-muted-color: rgb(250, 66, 66);
+  --code-header-second-muted-color: rgb(255, 165, 0);
+  --code-header-third-muted-color: rgb(2, 184, 2);
   --code-header-icon-color: #c9c8c8;
   --clipboard-checked-color: #43c743;
 


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->
Beautify the three dots of the markdown code block with different colors.
I only modified the color, it won't cause any other problems.

The following files have undergone changes:
- _sass/themes/_light.scss
- _sass/themes/_dark.scss
- _sass/base/_syntax.scss

## Additional context
<!-- e.g. Fixes #(issue) -->
The modified style can be viewed in the following image.

light mode:
![image](https://github.com/user-attachments/assets/df2c6d0c-ef67-454d-af38-13612e61b1d4)
dark mode:
![image](https://github.com/user-attachments/assets/be0b2274-b17d-4921-a4ae-5df98a633542)
