### PR TITLE
Fix typo in 2019-08-08-write-a-new-post.md

### DIFF
--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -21,7 +21,7 @@ Basically, you need to fill the [Front Matter](https://jekyllrb.com/docs/front-m
 ---
 title: TITLE
 date: YYYY-MM-DD HH:MM:SS +/-TTTT
-categories: [TOP_CATEGORIE, SUB_CATEGORIE]
+categories: [TOP_CATEGORY, SUB_CATEGORY]
 tags: [TAG]     # TAG names should always be lowercase
 ---
 ```


### PR DESCRIPTION

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Sorry for this tiny nitpick PR... it just fixes the spelling of "category" in the post that I couldn't unsee.

If "categorie" was supposed to reflect the Dutch, Italian, or Romanian spelling, please disregard this.  :)

https://en.wiktionary.org/wiki/categorie
