### PR TITLE
fix(seo): improve page speed by adding aria-label to enhance accessib…

### DIFF
--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -40,7 +40,7 @@
     </nav>
     <!-- endof #breadcrumb -->
 
-    <button type="button" id="sidebar-trigger" class="btn btn-link">
+    <button type="button" id="sidebar-trigger" class="btn btn-link" aria-label="Sidebar">
       <i class="fas fa-bars fa-fw"></i>
     </button>
 
@@ -55,7 +55,7 @@
       {% endif %}
     </div>
 
-    <button type="button" id="search-trigger" class="btn btn-link">
+    <button type="button" id="search-trigger" class="btn btn-link" aria-label="Search">
       <i class="fas fa-search fa-fw"></i>
     </button>
 


### PR DESCRIPTION

## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->
This pull request addresses an issue with the PageSpeed score where the absence of aria-label attributes was leading to score penalties. The aria-label has been added to relevant elements to improve accessibility and meet best practices for web accessibility, resulting in a more favorable PageSpeed performance.

## Additional context
<!-- e.g. Fixes #(issue) -->
Problem Screenshot in PageSpeed

![telegram-cloud-photo-size-4-5936051236283466237-y](https://github.com/user-attachments/assets/9d39ac46-6a7d-4598-9a2f-bcf5ae5875e2)

