### PR TITLE
Add ja-JP.yml

### DIFF
--- a/_data/locales/ja-JP.yml
+++ b/_data/locales/ja-JP.yml
@@ -1,0 +1,91 @@
+# The layout text of site
+
+# ----- Commons label -----
+
+layout:
+  post: Post
+  category: Category
+  tag: Tag
+
+# The tabs of sidebar
+tabs:
+  # format: <filename_without_extension>: <value>
+  home: ホーム
+  categories: カテゴリー
+  tags: タグ
+  archives: アーカイブ
+  about: このサイトについて
+
+# the text displayed in the search bar & search results
+search:
+  hint: 検索
+  cancel: キャンセル
+  no_results: 該当なし
+
+panel:
+  lastmod: 最近更新された投稿
+  trending_tags: トレンドのタグ
+  toc: Contents
+
+copyright:
+  # Shown at the bottom of the post
+  license:
+    template: This post is licensed under :LICENSE_NAME by the author.
+    name: CC BY 4.0
+    link: https://creativecommons.org/licenses/by/4.0/
+
+  # Displayed in the footer
+  brief: Some rights reserved.
+  verbose: >-
+    Except where otherwise noted, the blog posts on this site are licensed
+    under the Creative Commons Attribution 4.0 International (CC BY 4.0) License by the author.
+
+meta: Using the :THEME theme for :PLATFORM.
+
+not_found:
+  statement: Sorry, we've misplaced that URL or it's pointing to something that doesn't exist.
+
+notification:
+  update_found: 新しいバージョンが利用可能です
+  update: 更新
+
+# ----- Posts related labels -----
+
+post:
+  written_by: 投稿者
+  posted: 投稿日
+  updated: 更新日
+  words: words
+  pageview_measure: views
+  read_time:
+    unit: 分
+    prompt: ""
+  relate_posts: さらに読む
+  share: シェア
+  button:
+    next: 次
+    previous: 前
+    copy_code:
+      succeed: コピーしました
+    share_link:
+      title: リンクをコピー
+      succeed: リンクをコピーしました
+
+# Date time format.
+# See: <http://strftime.net/>, <https://day.js.org/docs/en/display/format>
+df:
+  post:
+    strftime: "%Y/%m/%d"
+    dayjs: "YYYY/M/D"
+  archives:
+    strftime: "%m/%d"
+    dayjs: "M/D"
+
+# categories page
+categories:
+  category_measure:
+    singular: カテゴリー
+    plural: カテゴリー
+  post_measure:
+    singular: 投稿
+    plural: 投稿

--- a/_data/locales/ja-JP.yml
+++ b/_data/locales/ja-JP.yml
@@ -78,8 +78,8 @@ df:
     strftime: "%Y/%m/%d"
     dayjs: "YYYY/M/D"
   archives:
-    strftime: "%m/%d"
-    dayjs: "M/D"
+    strftime: "%b"
+    dayjs: "MMM"
 
 # categories page
 categories:

--- a/_data/locales/ja-JP.yml
+++ b/_data/locales/ja-JP.yml
@@ -3,9 +3,9 @@
 # ----- Commons label -----
 
 layout:
-  post: Post
-  category: Category
-  tag: Tag
+  post: 投稿
+  category: カテゴリー
+  tag: タグ
 
 # The tabs of sidebar
 tabs:

--- a/_data/locales/ja-JP.yml
+++ b/_data/locales/ja-JP.yml
@@ -80,9 +80,5 @@ df:
 
 # categories page
 categories:
-  category_measure:
-    singular: カテゴリー
-    plural: カテゴリー
-  post_measure:
-    singular: 投稿
-    plural: 投稿
+  category_measure: カテゴリー
+  post_measure: 投稿

--- a/_data/locales/ja-JP.yml
+++ b/_data/locales/ja-JP.yml
@@ -40,7 +40,7 @@ copyright:
     Except where otherwise noted, the blog posts on this site are licensed
     under the Creative Commons Attribution 4.0 International (CC BY 4.0) License by the author.
 
-meta: :PLATFORM 用の :THEME テーマを使用しています。
+meta: :PLATFORM 用の :THEME を使用しています。
 
 not_found:
   statement: このURLは存在しないものを指し示しています。

--- a/_data/locales/ja-JP.yml
+++ b/_data/locales/ja-JP.yml
@@ -77,9 +77,6 @@ df:
   post:
     strftime: "%Y/%m/%d"
     dayjs: "YYYY/MM/DD"
-  archives:
-    strftime: "%b"
-    dayjs: "MMM"
 
 # categories page
 categories:

--- a/_data/locales/ja-JP.yml
+++ b/_data/locales/ja-JP.yml
@@ -25,7 +25,7 @@ search:
 panel:
   lastmod: 最近更新された投稿
   trending_tags: トレンドのタグ
-  toc: Contents
+  toc: コンテンツ
 
 copyright:
   # Shown at the bottom of the post
@@ -55,7 +55,7 @@ post:
   written_by: 投稿者
   posted: 投稿日
   updated: 更新日
-  words: words
+  words: 語
   pageview_measure: 回閲覧
   read_time:
     unit: 分

--- a/_data/locales/ja-JP.yml
+++ b/_data/locales/ja-JP.yml
@@ -76,10 +76,10 @@ post:
 df:
   post:
     strftime: "%Y/%m/%d"
-    dayjs: "YYYY/M/D"
+    dayjs: "YYYY/MM/DD"
   archives:
-    strftime: "%b"
-    dayjs: "MMM"
+    strftime: "%m /"
+    dayjs: "MM /"
 
 # categories page
 categories:

--- a/_data/locales/ja-JP.yml
+++ b/_data/locales/ja-JP.yml
@@ -56,10 +56,10 @@ post:
   posted: 投稿日
   updated: 更新日
   words: words
-  pageview_measure: views
+  pageview_measure: 回閲覧
   read_time:
     unit: 分
-    prompt: ""
+    prompt: で読めます
   relate_posts: さらに読む
   share: シェア
   button:

--- a/_data/locales/ja-JP.yml
+++ b/_data/locales/ja-JP.yml
@@ -78,8 +78,8 @@ df:
     strftime: "%Y/%m/%d"
     dayjs: "YYYY/MM/DD"
   archives:
-    strftime: "%m /"
-    dayjs: "MM /"
+    strftime: "%b"
+    dayjs: "MMM"
 
 # categories page
 categories:

--- a/_data/locales/ja-JP.yml
+++ b/_data/locales/ja-JP.yml
@@ -30,7 +30,7 @@ panel:
 copyright:
   # Shown at the bottom of the post
   license:
-    template: This post is licensed under :LICENSE_NAME by the author.
+    template: この投稿は投稿者によって :LICENSE_NAME の下でライセンスされています。
     name: CC BY 4.0
     link: https://creativecommons.org/licenses/by/4.0/
 
@@ -40,13 +40,13 @@ copyright:
     Except where otherwise noted, the blog posts on this site are licensed
     under the Creative Commons Attribution 4.0 International (CC BY 4.0) License by the author.
 
-meta: Using the :THEME theme for :PLATFORM.
+meta: :PLATFORM 用の :THEME テーマを使用しています。
 
 not_found:
-  statement: Sorry, we've misplaced that URL or it's pointing to something that doesn't exist.
+  statement: このURLは存在しないものを指し示しています。
 
 notification:
-  update_found: 新しいバージョンが利用可能です
+  update_found: 新しいバージョンが利用可能です。
   update: 更新
 
 # ----- Posts related labels -----


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->
This is the first version of `ja-JP.yml`.

'01 / 23' is preferred over '23 / 01,' '23 Jan,' or 'Jan 23' in Japan.
But, it is difficult because the date is hard coded.
Workaround: Copy [`_layouts/archives.html`](https://github.com/cotes2020/jekyll-theme-chirpy/blob/master/_layouts/archives.html) into your repository's `_layouts` and change the hard coded date (line 26-29):
```html
<span class="date day" data-ts="{{ ts }}" data-df="DD">{{ post.date | date: '%d' }}</span>
<span class="date month small text-muted ms-1" data-ts="{{ ts }}" data-df="{{ df_dayjs_m }}">
  {{ post.date | date: df_strftime_m }}
</span>
```
⬇️
```html
<span class="date day" data-ts="{{ ts }}" data-df="MM /">{{ post.date | date: '%m /' }}</span>
<span class="date month small text-muted ms-1" data-ts="{{ ts }}" data-df="DD">
  {{ post.date | date: '%d' }}
</span>
```
https://github.com/manabu-nakamura/chirpy-starter/blob/main/_layouts/archives.html
https://manabu-nakamura.github.io/chirpy-starter/archives/

https://github.com/manabu-nakamura/chirpy-starter
https://manabu-nakamura.github.io/chirpy-starter/

## Additional context
<!-- e.g. Fixes #(issue) -->
#2178