### PR TITLE
fix(search): fix visual glitch causing top bar to shrink during search

### DIFF
--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -1,6 +1,6 @@
 <!-- The Top Bar -->
 
-<header id="topbar-wrapper" aria-label="Top Bar">
+<header id="topbar-wrapper" class="flex-shrink-0" aria-label="Top Bar">
   <div
     id="topbar"
     class="d-flex align-items-center justify-content-between px-lg-3 h-100"


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
This PR fixes a visual glitch where the top bar would shrink by a few pixels when using the search bar.

Fixes #2337 
