### PR TITLE
fix: recognize global theme mode

### DIFF
--- a/_javascript/modules/theme.js
+++ b/_javascript/modules/theme.js
@@ -39,7 +39,10 @@ class Theme {
   }
 
   static get #mode() {
-    return sessionStorage.getItem(this.#modeKey);
+    return (
+      sessionStorage.getItem(this.#modeKey) ||
+      document.documentElement.getAttribute(this.#modeAttr)
+    );
   }
 
   static get #isDarkMode() {


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

The `theme.js` does not include the recognition of the global theme mode in the site configuration, which may cause initialization errors for other plugins that depend on the theme mode, such as `giscus`.

## Additional context

- Fixes #2356
