### PR TITLE
fix(css): prevent tags resizing on hover

### DIFF
--- a/_sass/abstracts/_placeholders.scss
+++ b/_sass/abstracts/_placeholders.scss
@@ -41,10 +41,14 @@
   white-space: nowrap;
 }
 
-%link-hover {
+%link-hover-no-border {
   color: #d2603a !important;
-  border-bottom: 1px solid #d2603a;
   text-decoration: none;
+}
+
+%link-hover {
+  @extend %link-hover-no-border;
+  border-bottom: 1px solid #d2603a;
 }
 
 %link-color {

--- a/_sass/abstracts/_placeholders.scss
+++ b/_sass/abstracts/_placeholders.scss
@@ -31,7 +31,10 @@
 }
 
 %tag-hover {
+  @extend %link-color;
+
   background: var(--tag-hover);
+  border-color: var(--tag-hover);
   transition: background 0.35s ease-in-out;
 }
 
@@ -41,14 +44,10 @@
   white-space: nowrap;
 }
 
-%link-hover-no-border {
-  color: #d2603a !important;
-  text-decoration: none;
-}
-
 %link-hover {
-  @extend %link-hover-no-border;
+  color: #d2603a !important;
   border-bottom: 1px solid #d2603a;
+  text-decoration: none;
 }
 
 %link-color {

--- a/_sass/pages/_post.scss
+++ b/_sass/pages/_post.scss
@@ -143,7 +143,6 @@ header {
 
   .post-tag {
     &:hover {
-      @extend %link-hover-no-border;
       @extend %tag-hover;
     }
   }

--- a/_sass/pages/_post.scss
+++ b/_sass/pages/_post.scss
@@ -143,9 +143,8 @@ header {
 
   .post-tag {
     &:hover {
-      @extend %link-hover;
+      @extend %link-hover-no-border;
       @extend %tag-hover;
-      @extend %no-bottom-border;
     }
   }
 }


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

This PR fixes a tiny visual imperfection when hovering over a tag.
[Screencast_20250417_005006.webm](https://github.com/user-attachments/assets/11cebbf1-fd4a-4cfa-b469-11190e6c5693)

I probably have some kind of OCD 😄 