### PR TITLE
fix: avoid mathjax loading failure on page refresh

### DIFF
--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -66,7 +66,7 @@
 
 {% if page.math %}
   <!-- MathJax -->
-  <script async src="{{ '/assets/js/data/mathjax.js' | relative_url }}"></script>
+  <script src="{{ '/assets/js/data/mathjax.js' | relative_url }}"></script>
   <script async src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
   <script id="MathJax-script" async src="{{ site.data.origin[type].mathjax.js | relative_url }}"></script>
 {% endif %}


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Ensure the correct loading order of MathJax configuration on page refresh.

Affected versions: `v7.0.0` ~ `v7.2.4`

## Additional context

Fixes #2351
