### PR TITLE
Fix image shadow not applied inside posts and add theme-based shadow color support

### DIFF
--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -474,3 +474,10 @@ mjx-container {
     margin-top: 3rem;
   }
 }
+
+/* --- image's shadow --- */
+
+img.shadow {
+  @extend %rounded;
+  box-shadow: 0 .5rem 1rem var(--img-shadow-color) !important;
+}

--- a/_sass/themes/_dark.scss
+++ b/_sass/themes/_dark.scss
@@ -81,6 +81,7 @@
   --prompt-warning-icon-color: rgb(255, 165, 0, 0.8);
   --prompt-danger-bg: rgb(86, 28, 8, 0.8);
   --prompt-danger-icon-color: #cd0202;
+  --img-shadow-color : rgb(255, 255, 255, 1);
 
   /* Tags */
   --tag-border: rgb(59, 79, 88);

--- a/_sass/themes/_light.scss
+++ b/_sass/themes/_light.scss
@@ -81,6 +81,7 @@
   --prompt-warning-icon-color: #ef9c03;
   --prompt-danger-bg: rgb(248, 215, 218, 0.56);
   --prompt-danger-icon-color: #df3c30;
+  --img-shadow-color : rgb(0, 0, 0, 1);
 
   /* Tags */
   --tag-border: #dee2e6;


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
Fixed a bug where the `.shadow` class was not applied to images inside post content.

Defined the missing `.shadow` class and added theme-based `--img-shadow` variables in `_light.scss` and `_dark.scss` to allow different shadow colors depending on the active theme.

## Additional context
None

![shadow bug fix](https://github.com/user-attachments/assets/2b826b7f-b601-4419-bbb7-3998e498fa1e)