### PR TITLE
fix: "search.json" Fails to Load Due to Invalid Escape Sequence

### DIFF
--- a/assets/js/data/search.json
+++ b/assets/js/data/search.json
@@ -14,7 +14,7 @@ swcache: true
     "categories": {{ post.categories | join: ', ' | jsonify }},
     "tags": {{ post.tags | join: ', ' | jsonify }},
     "date": "{{ post.date }}",
-    "content": "{{ description }}"
+    "content": {{ description | jsonify }}
   }{% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]


### PR DESCRIPTION
## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description

Added `jsonify` to escape special characters in post descriptions. This prevents errors like:

```
"content": "Path: C:\Program Files\App"
```
which breaks JSON parsing.


## Additional context
<!-- e.g. Fixes #(issue) -->

Fixes #2416 
