### PR TITLE
refactor(sidebar): adds condition for github/twitter username when di…

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -54,9 +54,13 @@
     {% for entry in site.data.contact %}
       {% case entry.type %}
         {% when 'github', 'twitter' %}
-          {%- capture url -%}
-            https://{{ entry.type }}.com/{{ site[entry.type].username }}
-          {%- endcapture -%}
+          {% if site[entry.type].username %}
+            {%- capture url -%}
+              https://{{ entry.type }}.com/{{ site[entry.type].username }}
+            {%- endcapture -%}
+          {% else %}
+            {% assign url = nil %}
+          {% endif %}
         {% when 'email' %}
           {% assign email = site.social.email | split: '@' %}
           {%- capture url -%}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -52,17 +52,21 @@
     {% endunless %}
 
     {% for entry in site.data.contact %}
+      {%- assign url = null -%}
+
       {% case entry.type %}
         {% when 'github', 'twitter' %}
-          {% if site[entry.type].username %}
-            {%- capture url -%}
-              https://{{ entry.type }}.com/{{ site[entry.type].username }}
-            {%- endcapture -%}
-          {% else %}
-            {% assign url = nil %}
-          {% endif %}
+          {%- unless site[entry.type].username -%}
+            {%- continue -%}
+          {%- endunless -%}
+          {%- capture url -%}
+            https://{{ entry.type }}.com/{{ site[entry.type].username }}
+          {%- endcapture -%}
         {% when 'email' %}
-          {% assign email = site.social.email | split: '@' %}
+          {%- unless site.social.email -%}
+            {%- continue -%}
+          {%- endunless -%}
+          {%- assign email = site.social.email | split: '@' -%}
           {%- capture url -%}
             javascript:location.href = 'mailto:' + ['{{ email[0] }}','{{ email[1] }}'].join('@')
           {%- endcapture -%}


### PR DESCRIPTION
Ensures a GitHub or Twitter username is configured in `_config.yml` before displaying them in the sidebar. Adds a conditional to capture/assign `url` so that it is `nil` if no username was provided. That way when the check for `url` is done for building the link, it will be skipped if no username is configured.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (refactoring and improving code)

## Description
Before this commit, GitHub and Twitter icons would be displayed on the sidebar, even if you deleted the username from `_config.yml`. In that case, the logo would just appear with a link to the root site (e.g. twitter.com instead of twitter.com/some_user). This fix adds logic so that when `_includes/sidebar.html` is rendered it will check if `_config.yml` has an entry for it. If no entry is configured the icon will not be displayed.