### PR TITLE
feat: add support for the function of reposting articles

### DIFF
--- a/_data/locales/ar.yml
+++ b/_data/locales/ar.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: بواسطة
   posted: نشّر
+  original_written_by: "كُتِبَ الأصل بواسطة"
+  reposted_from: "مُعاد نشره من"
+  original_source: "المصدر الأصلي"
   updated: حدّث
   words: كلمات
   pageview_measure: مشاهدات

--- a/_data/locales/bg-BG.yml
+++ b/_data/locales/bg-BG.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: Автор
   posted: Публикувана
+  original_written_by: "Оригиналът е написан от"
+  reposted_from: "Препубликувано от"
+  original_source: "Оригинален източник"
   updated: Обновена
   words: думи
   pageview_measure: преглеждания

--- a/_data/locales/ca-ES.yml
+++ b/_data/locales/ca-ES.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: Per
   posted: Publicat
+  original_written_by: "Original escrit per"
+  reposted_from: "Republicat des de"
+  original_source: "Font original"
   updated: Actualitzat
   words: paraules
   pageview_measure: visites

--- a/_data/locales/cs-CZ.yml
+++ b/_data/locales/cs-CZ.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: Od
   posted: Zveřejněno
+  original_written_by: "Původně napsal"
+  reposted_from: "Přetištěno z"
+  original_source: "Původní zdroj"
   updated: Aktualizováno
   words: slova
   pageview_measure: zhlednutí

--- a/_data/locales/da-DK.yml
+++ b/_data/locales/da-DK.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: Af
   posted: Udgivet
+  original_written_by: "Oprindeligt skrevet af"
+  reposted_from: "Genopslået fra"
+  original_source: "Oprindelig kilde"
   updated: Opdateret
   words: ord
   pageview_measure: visninger

--- a/_data/locales/de-DE.yml
+++ b/_data/locales/de-DE.yml
@@ -53,6 +53,9 @@ notification:
 post:
   written_by: Von
   posted: Veröffentlicht
+  original_written_by: "Ursprünglich geschrieben von"
+  reposted_from: "Wiederveröffentlicht von"
+  original_source: "Ursprüngliche Quelle"
   updated: Aktualisiert
   words: Wörter
   pageview_measure: Aufrufe

--- a/_data/locales/dv‑MV.yml
+++ b/_data/locales/dv‑MV.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: ލެކްއޯލް
   posted: ޕޯސްޓްކުރެވި
+  original_written_by: "އަސްލު ލިޔަފައިވާ"
+  reposted_from: "އިތުރަށް ނެރުނީ"
+  original_source: "އަސްލު މައްސަރު"
   updated: އޮޕްޑޭޓްކުރެވި
   words: ބަސް
   pageview_measure: ބަނޑުކުރާ

--- a/_data/locales/el-GR.yml
+++ b/_data/locales/el-GR.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: Από
   posted: Δημοσιεύθηκε
+  original_written_by: "Γράφτηκε αρχικά από"
+  reposted_from: "Επανδημοσιεύτηκε από"
+  original_source: "Πρωτότυπη πηγή"
   updated: Ενημερώθηκε
   words: λέξεις
   pageview_measure: προβολές

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: By
   posted: Posted
+  original_written_by: "Original written by"
+  reposted_from: "Reposted from"
+  original_source: "Original source"
   updated: Updated
   words: words
   pageview_measure: views

--- a/_data/locales/es-ES.yml
+++ b/_data/locales/es-ES.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: Por
   posted: Publicado
+  original_written_by: "Original escrito por"
+  reposted_from: "Republicado desde"
+  original_source: "Fuente original"
   updated: Actualizado
   words: palabras
   pageview_measure: visitas

--- a/_data/locales/fa-IR.yml
+++ b/_data/locales/fa-IR.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: نوشته شده توسط
   posted: منتشر شده
+  original_written_by: "نوشته شده اولیه توسط"
+  reposted_from: " منتشر شده از"
+  original_source: "منبع اصلی"
   updated: به‌روزرسانی شده
   words: کلمه
   pageview_measure: بازدید

--- a/_data/locales/fi-FI.yml
+++ b/_data/locales/fi-FI.yml
@@ -53,6 +53,9 @@ notification:
 post:
   written_by: Kirjoittaja
   posted: Julkaistu
+  original_written_by: "Alun perin kirjoittanut"
+  reposted_from: "Uudelleenjulkaistu lähteestä"
+  original_source: "Alkuperäinen lähde"
   updated: Päivitetty
   words: sanaa
   pageview_measure: katselukertoja

--- a/_data/locales/fr-FR.yml
+++ b/_data/locales/fr-FR.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: Par
   posted: Posté
+  original_written_by: "Original écrit par"
+  reposted_from: "Republié depuis"
+  original_source: "Source originale"
   updated: Mis à jour
   words: mots
   pageview_measure: vues

--- a/_data/locales/hu-HU.yml
+++ b/_data/locales/hu-HU.yml
@@ -55,6 +55,9 @@ notification:
 post:
   written_by: Szerző
   posted: Létrehozva
+  original_written_by: "Eredetileg írta"
+  reposted_from: "Újraközölve innen:"
+  original_source: "Eredeti forrás"
   updated: Frissítve
   words: szó
   pageview_measure: látogató

--- a/_data/locales/id-ID.yml
+++ b/_data/locales/id-ID.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: Oleh
   posted: Diterbitkan
+  original_written_by: "Ditulis oleh"
+  reposted_from: "Diposting ulang dari"
+  original_source: "Sumber asli"
   updated: Diperbarui
   words: kata
   pageview_measure: dilihat

--- a/_data/locales/it-IT.yml
+++ b/_data/locales/it-IT.yml
@@ -53,6 +53,9 @@ notification:
 post:
   written_by: Da
   posted: Postato
+  original_written_by: "Scritto originalmente da"
+  reposted_from: "Ripubblicato da"
+  original_source: "Fonte originale"
   updated: Aggiornato
   words: parole
   pageview_measure: visioni

--- a/_data/locales/ja-JP.yml
+++ b/_data/locales/ja-JP.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: 投稿者
   posted: 投稿日
+  original_written_by: "原作者"
+  reposted_from: "転載元"
+  original_source: "原文のソース"
   updated: 更新日
   words: 語
   pageview_measure: 回閲覧

--- a/_data/locales/ko-KR.yml
+++ b/_data/locales/ko-KR.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: By
   posted: 게시
+  original_written_by: "원작자"
+  reposted_from: "출처"
+  original_source: "원본 출처"
   updated: 업데이트
   words: 단어
   pageview_measure: 조회

--- a/_data/locales/ku-IQ.yml
+++ b/_data/locales/ku-IQ.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: نووسەر
   posted: بڵاوکراوەتەوە
+  original_written_by: "Ji aliyê"
+  reposted_from: "Ji"
+  original_source: "Çavkaniya eslî"
   updated: نوێکراوەتەوە
   words: وشە
   pageview_measure: بینین

--- a/_data/locales/my-MM.yml
+++ b/_data/locales/my-MM.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: ကရေးသားခဲ့သည်။
   posted: တင်ထားခဲ့သည်။
+  original_written_by: "မူရင်းရေးသူ"
+  reposted_from: "မှတစ်ဆင့် ပြန်လည်ဖော်ပြ"
+  original_source: "မူရင်းအရင်းအမြစ်"
   updated: မွမ်းမံထားခဲ့သည်။
   words: စကားလုံးများ
   pageview_measure: အမြင်များ

--- a/_data/locales/nl-NL.yml
+++ b/_data/locales/nl-NL.yml
@@ -53,6 +53,9 @@ notification:
 post:
   written_by: Door
   posted: Posted
+  original_written_by: "Oorspronkelijk geschreven door"
+  reposted_from: "Gerepubliceerd van"
+  original_source: "Oorspronkelijke bron"
   updated: Bijgewerkt
   words: woorden
   pageview_measure: Gelezen

--- a/_data/locales/ps‑AF.yml
+++ b/_data/locales/ps‑AF.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: لیکوال
   posted: خپره شوې
+  original_written_by: "اصلي ليکوال"
+  reposted_from: "د ... څخه بياختر شوی"
+  original_source: "اصلي سرچینه"
   updated: تازه شوې
   words: کلمې
   pageview_measure: کتنې

--- a/_data/locales/pt-BR.yml
+++ b/_data/locales/pt-BR.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: Por
   posted: Postado em
+  original_written_by: "Escrito originalmente por"
+  reposted_from: "Republicado de"
+  original_source: "Fonte original"
   updated: Atualizado
   words: palavras
   pageview_measure: visualizações

--- a/_data/locales/ru-RU.yml
+++ b/_data/locales/ru-RU.yml
@@ -53,6 +53,9 @@ notification:
 post:
   written_by: Автор
   posted: Опубликовано
+  original_written_by: "Автор оригинала"
+  reposted_from: "Перепечатано из"
+  original_source: "Оригинальный источник"
   updated: Обновлено
   words: слов
   pageview_measure: просмотров

--- a/_data/locales/sl-SI.yml
+++ b/_data/locales/sl-SI.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: Od #By
   posted: Objavljeno #Posted
+  original_written_by: "Izvirno napisal"
+  reposted_from: "Objavljeno prek"
+  original_source: "Izvirni vir"
   updated: Posodobljeno #Updated
   words: besede #words
   pageview_measure: ogledi #views

--- a/_data/locales/sv-SE.yml
+++ b/_data/locales/sv-SE.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: Av
   posted: Postad
+  original_written_by: "Ursprungligen skriven av"
+  reposted_from: "Ompublicerad från"
+  original_source: "Originalkälla"
   updated: Uppdaterad
   words: ord
   pageview_measure: visningar

--- a/_data/locales/th.yml
+++ b/_data/locales/th.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: โดย
   posted: โพสต์เมื่อ
+  original_written_by: "เขียนโดย"
+  reposted_from: "โพสต์ใหม่จาก"
+  original_source: "แหล่งที่มาเดิม"
   updated: อัปเดตเมื่อ
   words: คำ
   pageview_measure: ครั้ง

--- a/_data/locales/tr-TR.yml
+++ b/_data/locales/tr-TR.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: Yazan
   posted: Gönderim
+  original_written_by: "Orijinal Yazar"
+  reposted_from: "Şuradan alındı"
+  original_source: "Orijinal Kaynak"
   updated: Güncelleme
   words: sözcük
   pageview_measure: görüntülenme

--- a/_data/locales/uk-UA.yml
+++ b/_data/locales/uk-UA.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: Автор
   posted: Час публікації
+  original_written_by: "Автор оригіналу"
+  reposted_from: "Переопубліковано з"
+  original_source: "Джерело"
   updated: Оновлено
   words: слів
   pageview_measure: переглядів

--- a/_data/locales/ur-PK.yml
+++ b/_data/locales/ur-PK.yml
@@ -54,6 +54,9 @@ notification:
 post:
   written_by: از
   posted: شائع شدہ
+  original_written_by: "اصل مصنف"
+  reposted_from: "یہاں سے reposted"
+  original_source: "اصل ماخذ"
   updated: اپ ڈیٹ شدہ
   words: لفظ
   pageview_measure: مشاہدات

--- a/_data/locales/vi-VN.yml
+++ b/_data/locales/vi-VN.yml
@@ -53,6 +53,9 @@ notification:
 post:
   written_by: Viết bởi
   posted: Đăng lúc
+  original_written_by: "Được viết bởi"
+  reposted_from: "Đăng lại từ"
+  original_source: "Nguồn gốc"
   updated: Cập nhật lúc
   words: từ
   pageview_measure: lượt xem

--- a/_data/locales/zh-CN.yml
+++ b/_data/locales/zh-CN.yml
@@ -53,6 +53,9 @@ notification:
 post:
   written_by: 作者
   posted: 发表于
+  original_written_by: 原作者
+  reposted_from: 转载自
+  original_source: 文章来源
   updated: 更新于
   words: 字
   pageview_measure: 次浏览

--- a/_data/locales/zh-TW.yml
+++ b/_data/locales/zh-TW.yml
@@ -53,6 +53,9 @@ notification:
 post:
   written_by: 作者
   posted: 發布於
+  original_written_by: "原作者"
+  reposted_from: "轉載自"
+  original_source: "文章來源"
   updated: 更新於
   words: 字
   pageview_measure: 次瀏覽

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -55,30 +55,60 @@ script_includes:
 
       <div class="d-flex justify-content-between">
         <!-- author(s) -->
-        <span>
-          {% if page.author %}
-            {% assign authors = page.author %}
-          {% elsif page.authors %}
-            {% assign authors = page.authors %}
+        <div>
+          <!-- reposted article information block -->
+          {% if page.original_url %}
+            <div class="post-meta text-muted">
+              {% if page.original_author %}
+                <span>
+                  {{ site.data.locales[lang].post.original_written_by }}
+                  <em>
+                    {% if page.original_author %}{{ page.original_author }}{% else
+                    %}{{ site.data.locales[lang].post.original_author }}{% endif %}
+                  </em>
+                </span>
+                <br />
+              {% endif %}
+              <span class="text-muted">
+                {{ site.data.locales[lang].post.reposted_from }}
+                <a
+                  href="{{ page.original_url }}"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {{ page.original_source | default:
+                  site.data.locales[lang].post.original_source }}
+                </a>
+              </span>
+            </div>
+          {% else %}
+            <!-- original article information block -->
+            <span>
+              {% if page.author %}
+                {% assign authors = page.author %}
+              {% elsif page.authors %}
+                {% assign authors = page.authors %}
+              {% endif %}
+
+              {{ site.data.locales[lang].post.written_by }}
+
+              <em>
+                {% if authors %}
+                  {% for author in authors %}
+                    {% if site.data.authors[author].url -%}
+                      <a href="{{ site.data.authors[author].url }}">{{ site.data.authors[author].name }}</a>
+                    {%- else -%}
+                      {{ site.data.authors[author].name }}
+                    {%- endif %}
+                    {% unless forloop.last %}{{ '</em>, <em>' }}{% endunless %}
+                  {% endfor %}
+                {% else %}
+                  <a href="{{ site.social.links[0] }}">{{ site.social.name }}</a>
+                {% endif %}
+              </em>
+            </span>
           {% endif %}
-
-          {{ site.data.locales[lang].post.written_by }}
-
-          <em>
-            {% if authors %}
-              {% for author in authors %}
-                {% if site.data.authors[author].url -%}
-                  <a href="{{ site.data.authors[author].url }}">{{ site.data.authors[author].name }}</a>
-                {%- else -%}
-                  {{ site.data.authors[author].name }}
-                {%- endif %}
-                {% unless forloop.last %}{{ '</em>, <em>' }}{% endunless %}
-              {% endfor %}
-            {% else %}
-              <a href="{{ site.social.links[0] }}">{{ site.social.name }}</a>
-            {% endif %}
-          </em>
-        </span>
+        </div>
 
         <div>
           <!-- pageviews -->

--- a/_posts/2019-08-08-write-a-new-post.md
+++ b/_posts/2019-08-08-write-a-new-post.md
@@ -85,6 +85,21 @@ description: Short summary of the post.
 
 Additionally, the `description` text will also be displayed under the post title on the post's page.
 
+### Reposted Articles
+
+For reposted articles, you can add the following fields to the Front Matter to indicate the original source:
+
+```yaml
+---
+original_url: https://example.com/posts/sample-article
+original_author: Example Author  # Optional
+original_source: Example Title Name # Default: "Original Source"
+---
+```
+
+> These fields help maintain proper attribution and credit the original content creator when sharing republished articles.
+{: .prompt-info }
+
 ## Table of Contents
 
 By default, the **T**able **o**f **C**ontents (TOC) is displayed on the right panel of the post. If you want to turn it off globally, go to `_config.yml`{: .filepath} and set the value of variable `toc` to `false`. If you want to turn off TOC for a specific post, add the following to the post's [Front Matter](https://jekyllrb.com/docs/front-matter/):


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
This pull request introduces a new feature that enables users to repost articles from external sources while ensuring proper attribution to the original content creators. The implementation enhances the post layout to conditionally display original author information and source links when an article is reposted.

Key changes include:
- Addition of new front matter variables: `original_url`, `original_author`, and `original_source` to capture attribution metadata
- Modification of the post layout template to render a dedicated attribution section for reposted content, clearly distinguishing it from original posts
- Inclusion of new localization strings across all 33 supported languages to maintain consistent and accurate attribution messaging in every language
- Updates to example post documentation to illustrate correct usage of the new front matter variables

This feature ensures that reposted content maintains integrity and proper credit to original authors and publications, aligning with best practices for content sharing and attribution.

<img width="1704" height="490" alt="image" src="https://github.com/user-attachments/assets/3e1bb2d0-fb92-4368-b616-0c6030a326a9" />
<img width="2940" height="1558" alt="image" src="https://github.com/user-attachments/assets/c783d926-ab1b-4801-9810-c13660c1f4de" />

## Additional context
<!-- e.g. Fixes #(issue) -->
