### PR TITLE
feat(images): add referrerpolicy attribute for privacy protection

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,6 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="referrer" content="never">
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f7f7f7">
   <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1b1b1e">
   <meta name="mobile-web-app-capable" content="yes">

--- a/_includes/refactor-content.html
+++ b/_includes/refactor-content.html
@@ -161,6 +161,9 @@
       {% assign _left = _left | append: ' loading="lazy"' %}
     {% endif %}
 
+    <!-- add referrerpolicy for images -->
+    {% assign _left = _left | append: ' referrerpolicy="no-referrer"' %}
+
     {% if page.layout == 'home' %}
       <!-- create the image wrapper -->
       {% assign _wrapper_start = '<div class="preview-img ' | append: _wrapper_class | append: '">' %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -7,7 +7,7 @@
         {%- capture avatar_url -%}
           {% include media-url.html src=site.avatar %}
         {%- endcapture -%}
-        <img src="{{- avatar_url -}}" width="112" height="112" alt="avatar" onerror="this.style.display='none'">
+        <img src="{{- avatar_url -}}" width="112" height="112" alt="avatar" referrerpolicy="no-referrer" onerror="this.style.display='none'">
       {%- endif -%}
     </a>
 


### PR DESCRIPTION
## Type of change
- [x] New feature (non-breaking change which adds functionality)


## Description

This PR adds referrer policy support to prevent HTTP Referer headers from being sent when loading images. This enhancement is particularly useful for:

1. **Privacy protection**: Prevents external image hosts from tracking where images are being displayed
2. **Hotlink protection bypass**: Enables displaying images from platforms with referrer-based hotlink protection (e.g., WeChat Official Account images)
3. **Enhanced security**: Reduces information leakage to third-party image servers

### Changes Made

#### 1. Meta Tag in Head (head.html)
Added `<meta name="referrer" content="never">` to the document head for global referrer policy.
#### 2. Image Tag Attributes (refactor-content.html)
Modified the image processing logic to inject `referrerpolicy="no-referrer"` attribute to all dynamically generated `<img>` tags in post content.
#### 3. Sidebar Avatar (sidebar.html)
Added `referrerpolicy="no-referrer"` attribute to the avatar image in the sidebar.

## Additional context
Opened #2586 

## Testing

Tested with:
- WeChat Official Account images (mmbiz.qpic.cn domain)
- Various image formats (jpg, png, gif)
- Both lazy-loaded and LQIP images
- Avatar images in sidebar
- Images with different Kramdown attributes (.shadow)
- 
### Branch Information

- Base branch: `master` (or latest release branch)
- Feature branch: `feat/img-referrerpolicy`
- Commits: 2 commits
  - feat(images): add referrerpolicy attribute for privacy protection
  - feat(privacy): add referrer meta tag to prevent information leakage


