### PR TITLE
fix(): resolve issue with <a> tag wrapping for <img>

### DIFF
--- a/_includes/refactor-content.html
+++ b/_includes/refactor-content.html
@@ -171,7 +171,6 @@
     {% else %}
       <!-- make sure the `<img>` is wrapped by `<a>` -->
       {% assign _parent = _right | remove_first: ">" | strip | slice: 0, 4 %}
-      <!-- logging: [{{ _parent }}] -->
 
       {% if _parent == '</a>' %}
         <!-- add class to existing <a> tag -->

--- a/_includes/refactor-content.html
+++ b/_includes/refactor-content.html
@@ -170,13 +170,14 @@
 
     {% else %}
       <!-- make sure the `<img>` is wrapped by `<a>` -->
-      {% assign _parent = _right | remove_first: ">" | strip | slice: 0, 3 %}
+      {% assign _parent = _right | remove_first: ">" | strip | slice: 0, 4 %}
+      <!-- logging: [{{ _parent }}] -->
 
       {% if _parent == '</a>' %}
         <!-- add class to existing <a> tag -->
         {% assign _size = _img_content | strip | size | minus: 1 %}
         {% capture _class %}
-          class="img-link{% unless _lqip %} shimmer{% endunless %}"
+          class="popup img-link{% unless _lqip %} shimmer{% endunless %}"
         {% endcapture %}
         {% assign _img_content = _img_content | strip | slice: 0, _size | append: _class | append: '>' %}
 

--- a/_includes/refactor-content.html
+++ b/_includes/refactor-content.html
@@ -170,15 +170,15 @@
 
     {% else %}
       <!-- make sure the `<img>` is wrapped by `<a>` -->
-      {% assign _parent = _right | slice: 1, 4 %}
+      {% assign _parent = _right | remove_first: ">" | strip | slice: 0, 3 %}
 
       {% if _parent == '</a>' %}
-        <!-- add class to exist <a> tag -->
-        {% assign _size = _img_content | size | minus: 1 %}
+        <!-- add class to existing <a> tag -->
+        {% assign _size = _img_content | strip | size | minus: 1 %}
         {% capture _class %}
           class="img-link{% unless _lqip %} shimmer{% endunless %}"
         {% endcapture %}
-        {% assign _img_content = _img_content | slice: 0, _size | append: _class | append: '>' %}
+        {% assign _img_content = _img_content | strip | slice: 0, _size | append: _class | append: '>' %}
 
       {% else %}
         <!-- create the image wrapper -->


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Fixes the HTML generation to better handle whitespace, when wrapping <img> tags with <a>

## Additional context
Fixes #2596 
