### PR TITLE
feat(giscus): allow giscus data-loading to be eager (not lazy)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -129,6 +129,7 @@ comments:
     input_position: # optional, default to 'bottom'
     lang: # optional, default to the value of `site.lang`
     reactions_enabled: # optional, default to the value of `1`
+    data_loading: # optional, default to 'lazy'
 
 # Self-hosted static assets, optional › https://github.com/cotes2020/chirpy-static-assets
 assets:

--- a/_config.yml
+++ b/_config.yml
@@ -129,7 +129,7 @@ comments:
     input_position: # optional, default to 'bottom'
     lang: # optional, default to the value of `site.lang`
     reactions_enabled: # optional, default to the value of `1`
-    data_loading: # optional, default to 'lazy'
+    data_loading: # optional, default to 'lazy'. Set to 'eager' to load giscus immediately with page.
 
 # Self-hosted static assets, optional › https://github.com/cotes2020/chirpy-static-assets
 assets:

--- a/_includes/comments/giscus.html
+++ b/_includes/comments/giscus.html
@@ -23,7 +23,7 @@
       'data-theme': initTheme,
       'data-input-position': '{{ site.comments.giscus.input_position | default: 'bottom' }}',
       'data-lang': lang,
-      'data-loading': 'lazy',
+      'data-loading': '{{ site.comments.giscus.data_loading | default: 'lazy' }}',
       crossorigin: 'anonymous',
       async: ''
     };


### PR DESCRIPTION
## Type of change
- [X] New feature (non-breaking change which adds functionality)

## Description
Add a config option for Giscus comments, which allows you to set the iframe data-loading. Currently, it's hard-coded for lazy loading, but this will enable you to set it to load eagerly when the page loads. I personally don't think it's a good user experience for the user to wait for the comments to load once they scroll to the bottom of the page. The default has been kept as lazy loading.

