### PR TITLE
chore(git): Add .DS_Store to .gitignore for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ package-lock.json
 # Misc
 _sass/vendors
 assets/js/dist
+
+# macOS legacy
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,7 @@ package-lock.json
 _sass/vendors
 assets/js/dist
 
-# macOS legacy
+# Hidden system files
+*~
 .DS_Store
+Thumbs.db


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
macOS always leaves .DS_Store when editing or opening project, this PR added this rule to ignore it, which is also common practice for most open-source libraries.

## Additional context
N/A, just a boring .gitignore behavior.
