### PR TITLE
feat(comment): add https://isso-comments.de/ support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -110,7 +110,7 @@ toc: true
 
 comments:
   # Global switch for the post-comment system. Keeping it empty means disabled.
-  provider: # [disqus | utterances | giscus]
+  provider: # [disqus | utterances | giscus | isso]
   # The provider options are as follows:
   disqus:
     shortname: # fill with the Disqus shortname. › https://help.disqus.com/en/articles/1717111-what-s-a-shortname
@@ -129,6 +129,10 @@ comments:
     input_position: # optional, default to 'bottom'
     lang: # optional, default to the value of `site.lang`
     reactions_enabled: # optional, default to the value of `1`
+  isso:
+    server_url: # the URL of your Isso server, e.g. "https://comments.example.com"
+    script_name: # optional, default to the value `js/embed.min.js`
+
 
 # Self-hosted static assets, optional › https://github.com/cotes2020/chirpy-static-assets
 assets:

--- a/_includes/comments/isso.html
+++ b/_includes/comments/isso.html
@@ -1,0 +1,24 @@
+<script>
+  const issoThread = document.createElement('section');
+
+  issoThread.id = 'isso-thread';
+  issoThread.className = 'mt-4'; // Add some margin top
+  issoThread.setAttribute('data-isso-id', '{{ page.url }}');
+  issoThread.setAttribute('data-title', '{{ page.title | escape }}');
+
+  const footer = document.querySelector('footer');
+  if (footer) {
+    footer.insertAdjacentElement("beforebegin", issoThread);
+  }
+</script>
+
+<script data-isso="{{ site.comments.isso.server_url }}" src="{{ site.comments.isso.server_url }}{{ site.comments.isso.script_name | default: 'js/embed.min.js' }}"></script>
+
+<style>
+  #isso-thread * {
+    background-color: var(--main-bg);
+    background: var(--main-bg);
+    color: var(--main-color);
+    border-color: var(--main-border-color);
+  }
+</style>


### PR DESCRIPTION
## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Description
So far, there is no option for truely self hosted comments. Isso is rather simple (`pipx install isso` or installing it from AUR + some editing of the /etc/isso.cfg)

## Additional context
Some screenshots to prove that it works with dark+light theme

If you want me to host you an isso server for testing, message me.

Edit mode: dark
<img width="850" height="257" alt="image" src="https://github.com/user-attachments/assets/6769b9cf-78d7-4b4a-96e7-1e99109f5ce4" />

Preview mode: dark (that's why we need background: and background-color)
<img width="849" height="196" alt="image" src="https://github.com/user-attachments/assets/921c2c79-3f73-4aa3-8add-67057d1985b5" />

Edit mode + comment: white (logged in, so we have edit/delete)
<img width="840" height="371" alt="image" src="https://github.com/user-attachments/assets/c649f036-85c6-424c-83f5-e6fefb6d6ac0" />