### PR TITLE
Synchronize giscus theme state during lazy loading

### DIFF
--- a/_includes/comments/giscus.html
+++ b/_includes/comments/giscus.html
@@ -39,16 +39,25 @@
     addEventListener('message', (event) => {
       if (event.source === window && event.data && event.data.id === Theme.ID) {
         const newTheme = themeMapper[Theme.visualState];
-
         const message = {
           setConfig: {
             theme: newTheme
           }
         };
 
-        const giscus =
-          document.getElementsByClassName('giscus-frame')[0].contentWindow;
-        giscus.postMessage({ giscus: message }, 'https://giscus.app');
+        const iframe = document.querySelector('.giscus-frame');
+
+        if (!iframe) {
+          return;
+        }
+
+        if (iframe.classList.contains('giscus-frame--loading')) {
+          let url = new URL(iframe.src);
+          url.searchParams.set('theme', newTheme);
+          iframe.src = url.toString();
+        }
+
+        iframe.contentWindow.postMessage({ giscus: message }, 'https://giscus.app');
       }
     });
   })();


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Previously, theme switch events were lost if triggered before the Giscus iframe was fully loaded (e.g., when deferred by lazy loading or before the client script executed). This resulted in Giscus rendering with the outdated initial theme once it finally appeared in the viewport.

This commit handles these edge cases by:
1. Updating the `data-theme` attribute on the Giscus script node if the iframe hasn't been created yet.
2. Modifying the `theme` query parameter in the iframe's `src` URL if it is currently in a pending/lazy-loading state.