### PR TITLE
fix(mermaid): defer rendering until web fonts are ready

### DIFF
--- a/_javascript/modules/components/mermaid.js
+++ b/_javascript/modules/components/mermaid.js
@@ -46,13 +46,24 @@ export function loadMermaid() {
   const initTheme = themeMapper[Theme.visualState];
 
   let mermaidConf = {
-    theme: initTheme
+    theme: initTheme,
+    startOnLoad: false
   };
 
   const basicList = document.getElementsByClassName('language-mermaid');
   [...basicList].forEach(setNode);
 
   mermaid.initialize(mermaidConf);
+
+  // Defer rendering until web fonts are ready so Mermaid measures label
+  // widths with the correct font metrics, preventing text clipping inside
+  // SVG foreignObject when a web font is wider than the fallback font.
+  // Cap the wait at 2.5 s so a slow/blocked font source never stalls diagrams.
+  const fontsReady = document.fonts?.ready ?? Promise.resolve();
+  const timeout = new Promise((resolve) => setTimeout(resolve, 2500));
+  Promise.race([fontsReady, timeout]).then(() =>
+    mermaid.run().catch(console.error)
+  );
 
   if (Theme.switchable) {
     window.addEventListener('message', refreshTheme);


### PR DESCRIPTION
## Problem

When a web font loads after Mermaid has already measured label widths, the text appears wider than the allocated space and gets clipped by the SVG `foreignObject` default `overflow: hidden`.

**Root cause:** `loadMermaid()` calls `mermaid.initialize()` (with the default `startOnLoad: true`) immediately, without waiting for `document.fonts.ready`. Mermaid measures node label widths at render time using whatever font is available at that moment. If the web font has not arrived yet, measurements use the narrower fallback font; once the web font loads, the wider glyphs overflow the clipped `foreignObject` box.

This is reproducible on any page that uses a non-system web font (e.g. Google Fonts) together with Mermaid diagrams.

## Fix

- Set `startOnLoad: false` so Mermaid does not auto-render on `initialize()`.
- Defer `mermaid.run()` until `document.fonts.ready`, ensuring measurements happen after the final font is active.
- Guard against a slow or blocked font CDN with a 2.5 s timeout; if the timeout fires first, rendering proceeds anyway (any remaining clipping is minor since most fonts load well within that window).

## Changes

`_javascript/modules/components/mermaid.js` only — no layout, style, or config changes.