### PR TITLE
fix(mermaid): defer rendering until web fonts are ready

### DIFF
--- a/_javascript/modules/components/mermaid.js
+++ b/_javascript/modules/components/mermaid.js
@@ -46,13 +46,24 @@ export function loadMermaid() {
   const initTheme = themeMapper[Theme.visualState];
 
   let mermaidConf = {
-    theme: initTheme
+    theme: initTheme,
+    startOnLoad: false
   };
 
   const basicList = document.getElementsByClassName('language-mermaid');
   [...basicList].forEach(setNode);
 
   mermaid.initialize(mermaidConf);
+
+  // Defer rendering until web fonts are ready so Mermaid measures label
+  // widths with the correct font metrics, preventing text clipping inside
+  // SVG foreignObject when a web font is wider than the fallback font.
+  // Cap the wait at 2.5 s so a slow/blocked font source never stalls diagrams.
+  const fontsReady = document.fonts?.ready ?? Promise.resolve();
+  const timeout = new Promise((resolve) => setTimeout(resolve, 2500));
+  Promise.race([fontsReady, timeout]).then(() =>
+    mermaid.run().catch(console.error)
+  );
 
   if (Theme.switchable) {
     window.addEventListener('message', refreshTheme);


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Mermaid measures label widths at initialization time. When `loadMermaid()` calls `mermaid.initialize()` (default `startOnLoad: true`), Mermaid renders immediately — before the page's web font has finished loading. Width is measured with the narrower fallback font; once the web font arrives the glyphs are wider and overflow the already-sized `foreignObject` box, clipping the text (default `overflow: hidden`).

**Fix:**
- Set `startOnLoad: false` so `mermaid.initialize()` no longer auto-renders.
- Defer `mermaid.run()` until `document.fonts.ready`, so label widths are always measured with the final font.
- Guard against a slow or blocked font CDN with a 2.5 s timeout: if the timeout fires first, rendering proceeds anyway.

Only `_javascript/modules/components/mermaid.js` is changed. Lint (`npm run lint:js`) and build (`npm run build`) both pass locally.

## Additional context

Fixes #2753