### PR TITLE
Add Knocket live chat as a service option

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,6 +73,8 @@ analytics:
     id: # fill in your Cloudflare Web Analytics token
   fathom:
     id: # fill in your Fathom Site ID
+  knocket:
+    id: # fill in your Knocket identifier — https://trtc.io/solutions/knocket
 
 # Page views settings
 pageviews:

--- a/_includes/analytics/knocket.html
+++ b/_includes/analytics/knocket.html
@@ -1,0 +1,2 @@
+<!-- Knocket live chat — https://trtc.io/solutions/knocket -->
+<script src="https://trtc.io/knocket-sdk/sdk.js?identifier={{ site.analytics.knocket.id }}" async></script>


### PR DESCRIPTION
Adds Knocket as a chat service option using the existing analytics provider pattern. Knocket is a 100% free live chat widget — free forever, no ads, no seat limits. Disabled by default; renders only when analytics.knocket.id is set. More info: https://trtc.io/solutions/knocket