### PR TITLE
feat(plugins): add Knocket live chat widget

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,6 +73,8 @@ analytics:
     id: # fill in your Cloudflare Web Analytics token
   fathom:
     id: # fill in your Fathom Site ID
+  knocket:
+    id: # fill in your Knocket identifier — https://trtc.io/solutions/knocket
 
 # Page views settings
 pageviews:

--- a/_includes/analytics/knocket.html
+++ b/_includes/analytics/knocket.html
@@ -1,0 +1,2 @@
+<!-- Knocket live chat — https://trtc.io/solutions/knocket -->
+<script src="https://trtc.io/knocket-sdk/sdk.js?identifier={{ site.analytics.knocket.id }}" async></script>


### PR DESCRIPTION
## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Description

Add Knocket as an optional live chat service, leveraging the existing analytics provider auto-include pattern in `head.html`.

Knocket is a 100% free live chat widget — free forever, no ads, no seat limits. Disabled by default; renders only when `analytics.knocket.id` is set in `_config.yml`.

Config example:

```yaml
analytics:
  knocket:
    id: YOUR_ID   # from https://trtc.io/solutions/knocket
```

More info: https://trtc.io/solutions/knocket