### PR TITLE
fix(math): prevent long display equations from overflowing the page

### DIFF
--- a/assets/js/data/mathjax.js
+++ b/assets/js/data/mathjax.js
@@ -21,5 +21,9 @@ MathJax = {
     ],
     {%- comment -%} equation numbering {%- endcomment -%}
     tags: 'ams'
+  },
+  output: {
+    {%- comment -%} scroll long display equations instead of overflowing the page {%- endcomment -%}
+    displayOverflow: 'scroll'
   }
 };


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

On mobile-width viewports, a display equation wider than the content column extends past the right edge of the page and causes **page-level horizontal scrolling** — the whole layout shifts when swiping, and after a portrait ⇄ landscape rotation the page can end up with leftover horizontal scroll or not filling the viewport width.

This is a regression of #543 / #545: the `mjx-container` overflow rules were dropped when MathJax was bumped to v4 in 97a537e. MathJax 4 has a native option for exactly this — [`output.displayOverflow`](https://docs.mathjax.org/en/latest/options/output/index.html) — but it defaults to `'overflow'` (content just spills out). This PR sets it to `'scroll'`, so a long display equation scrolls inside its own container instead of widening the page.

**How to reproduce**: create a post with `math: true` and a display equation wider than the viewport, e.g.

```latex
$$
\mathbf{T} = \arg\min_{\mathbf{R},s,\mathbf{t}} \sum_{i=1}^{N} w_i \left\| s\mathbf{R}\mathbf{a}_i + \mathbf{t} - \mathbf{b}_i \right\|^2, \quad \text{subject to } \mathbf{R}^\top\mathbf{R} = \mathbf{I}, \; \det(\mathbf{R}) = 1, \; s > 0
$$
```

Measured on a 390 px viewport (Chrome, Pixel 8 emulation): `document.documentElement.scrollWidth` is **733 px before** and **390 px after** this change; the equation scrolls within its own box and inline math is unaffected. Also verified against the `text-and-typography` demo post (including AMS-numbered equations) with no visual changes.

| Before (page overflows) | After (equation scrolls in place) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/cornpip/jekyll-theme-chirpy/pr-assets/pr1-before.png) | ![after](https://raw.githubusercontent.com/cornpip/jekyll-theme-chirpy/pr-assets/pr1-after-scrolled.png) |

*(right screenshot shows the same equation scrolled to its end inside the container)*

An alternative would be restoring the old CSS (`mjx-container { overflow-x: auto; overflow-y: hidden; }`), which also works, but `displayOverflow` is the v4-native mechanism and is renderer-agnostic, so I went with the config option.

## Additional context

Regression introduced in 97a537e (MathJax 3.2.2 → 4.x); originally fixed by #545 for #543.
