### PR TITLE
fix(ui): truncate code block labels that overflow the viewport

### DIFF
--- a/_sass/base/_syntax.scss
+++ b/_sass/base/_syntax.scss
@@ -186,7 +186,12 @@ div {
 
   /* the label block */
   span {
+    /* truncate long labels instead of overflowing the viewport */
+    overflow: hidden;
+    min-width: 0;
     line-height: v.$code-header-height;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     /* label icon */
     i {

--- a/_sass/base/_syntax.scss
+++ b/_sass/base/_syntax.scss
@@ -188,7 +188,6 @@ div {
   span {
     /* truncate long labels instead of overflowing the viewport */
     overflow: hidden;
-    min-width: 0;
     line-height: v.$code-header-height;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/_sass/base/_syntax.scss
+++ b/_sass/base/_syntax.scss
@@ -132,7 +132,12 @@ div[class^='language-'] {
       &::before {
         content: '';
         display: inline-block;
+        flex-shrink: 0;
         margin-left: $dot-margin;
+
+        /* the 2nd/3rd dots are painted with box-shadow and take no layout
+          space — reserve it so a truncated label cannot overlap them */
+        margin-right: (v.$code-dot-size + v.$code-dot-gap) * 2;
         width: v.$code-dot-size;
         height: v.$code-dot-size;
         border-radius: 50%;
@@ -145,8 +150,9 @@ div[class^='language-'] {
       }
 
       span {
-        // center the text of label
-        margin-left: calc(($dot-margin + v.$code-dot-size) / 2 * -1);
+        /* fill the space between the dots and the copy button */
+        flex: 1;
+        text-align: center;
       }
     }
   }
@@ -189,6 +195,9 @@ div {
     /* truncate long labels instead of overflowing the viewport */
     overflow: hidden;
     line-height: v.$code-header-height;
+
+    /* color here (not ::after) so the span-rendered ellipsis matches the label */
+    color: var(--code-header-text-color);
     text-overflow: ellipsis;
     white-space: nowrap;
 
@@ -213,7 +222,6 @@ div {
       content: attr(data-label-text);
       font-size: 0.85rem;
       font-weight: 600;
-      color: var(--code-header-text-color);
     }
   }
 

--- a/_sass/base/_syntax.scss
+++ b/_sass/base/_syntax.scss
@@ -124,6 +124,87 @@ div[class^='language-'] {
   }
 
   .code-header {
+    @extend %no-cursor;
+
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: v.$code-header-height;
+    margin-left: 0.75rem;
+    margin-right: 0.25rem;
+
+    /* the label block */
+    span {
+      color: var(--code-header-text-color);
+      line-height: v.$code-header-height;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      /* label icon */
+      i {
+        font-size: 1rem;
+        width: v.$code-icon-width;
+        color: var(--code-header-icon-color);
+
+        &.small {
+          font-size: 70%;
+        }
+      }
+
+      @at-root [file] #{&} > i {
+        position: relative;
+        top: 1px; /* center the file icon */
+      }
+
+      /* label text */
+      &::after {
+        content: attr(data-label-text);
+        font-size: 0.85rem;
+        font-weight: 600;
+      }
+    }
+
+    /* clipboard */
+    button {
+      @extend %cursor-pointer;
+      @extend %rounded;
+
+      border: 1px solid transparent;
+      height: 2rem;
+      width: 2rem;
+      margin-right: 0.125rem;
+      padding: 0;
+      background-color: inherit;
+
+      i {
+        color: var(--code-header-icon-color);
+      }
+
+      &[timeout] {
+        &:hover {
+          border-color: var(--clipboard-checked-color);
+        }
+
+        i {
+          font-size: 90%;
+          color: var(--clipboard-checked-color);
+        }
+      }
+
+      &:focus {
+        outline: none;
+      }
+
+      &:not([timeout]):hover {
+        background-color: rgb(128 128 128 / 37%);
+
+        i {
+          color: white;
+        }
+      }
+    }
+
     @include bp.sm {
       @include mx.ml-mr(0);
 
@@ -132,12 +213,7 @@ div[class^='language-'] {
       &::before {
         content: '';
         display: inline-block;
-        flex-shrink: 0;
         margin-left: $dot-margin;
-
-        /* the 2nd/3rd dots are painted with box-shadow and take no layout
-          space — reserve it so a truncated label cannot overlap them */
-        margin-right: (v.$code-dot-size + v.$code-dot-gap) * 2;
         width: v.$code-dot-size;
         height: v.$code-dot-size;
         border-radius: 50%;
@@ -150,9 +226,11 @@ div[class^='language-'] {
       }
 
       span {
-        /* fill the space between the dots and the copy button */
-        flex: 1;
-        text-align: center;
+        margin-left: v.$code-icon-width * -1; // center the label text
+        max-width: calc(
+          100% - $dot-margin - (v.$code-dot-gap + v.$code-dot-size) * 3 -
+            v.$code-icon-width * 4
+        );
       }
     }
   }
@@ -175,92 +253,6 @@ div {
 
       .lineno {
         display: none;
-      }
-    }
-  }
-}
-
-.code-header {
-  @extend %no-cursor;
-
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  height: v.$code-header-height;
-  margin-left: 0.75rem;
-  margin-right: 0.25rem;
-
-  /* the label block */
-  span {
-    /* truncate long labels instead of overflowing the viewport */
-    overflow: hidden;
-    line-height: v.$code-header-height;
-
-    /* color here (not ::after) so the span-rendered ellipsis matches the label */
-    color: var(--code-header-text-color);
-    text-overflow: ellipsis;
-    white-space: nowrap;
-
-    /* label icon */
-    i {
-      font-size: 1rem;
-      width: v.$code-icon-width;
-      color: var(--code-header-icon-color);
-
-      &.small {
-        font-size: 70%;
-      }
-    }
-
-    @at-root [file] #{&} > i {
-      position: relative;
-      top: 1px; /* center the file icon */
-    }
-
-    /* label text */
-    &::after {
-      content: attr(data-label-text);
-      font-size: 0.85rem;
-      font-weight: 600;
-    }
-  }
-
-  /* clipboard */
-  button {
-    @extend %cursor-pointer;
-    @extend %rounded;
-
-    border: 1px solid transparent;
-    height: 2rem;
-    width: 2rem;
-    margin-right: 0.125rem;
-    padding: 0;
-    background-color: inherit;
-
-    i {
-      color: var(--code-header-icon-color);
-    }
-
-    &[timeout] {
-      &:hover {
-        border-color: var(--clipboard-checked-color);
-      }
-
-      i {
-        font-size: 90%;
-        color: var(--clipboard-checked-color);
-      }
-    }
-
-    &:focus {
-      outline: none;
-    }
-
-    &:not([timeout]):hover {
-      background-color: rgb(128 128 128 / 37%);
-
-      i {
-        color: white;
       }
     }
   }


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

The code block header label is rendered from `data-label-text` (`span::after`) without any width constraint. `.code-header` is a flex row and the label's default `min-width: auto` prevents the flex item from shrinking, so a long label — e.g. a long `file` path — pushes past the right edge of the viewport on mobile: the copy button is shoved off-screen and the page gets **page-level horizontal scrolling** (which also misbehaves across portrait ⇄ landscape rotations).

This PR lets the label flex item shrink (`min-width: 0`) and truncates it with an ellipsis, keeping the copy button in place.

**How to reproduce**: create a post with a code block labeled with a long file path:

````markdown
```cpp
int main() { return 0; }
```
{: file="mediapipe/modules/face_geometry/data/geometry_pipeline_metadata_landmarks.pbtxt" }
````

Measured on a 390 px viewport (Chrome, Pixel 8 emulation): `document.documentElement.scrollWidth` is **600 px before** and **390 px after** this change. Short labels (language names) are unaffected.

| Before (label overflows, copy button off-screen) | After (truncated, copy button visible) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/cornpip/jekyll-theme-chirpy/pr-assets/pr2-before.png) | ![after](https://raw.githubusercontent.com/cornpip/jekyll-theme-chirpy/pr-assets/pr2-after.png) |

## Additional context

`npm run lint:scss` passes.
