### PR TITLE
fix: og:image link is broken for posts that use a relative image with media_subpath

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,7 +21,7 @@
         {% include media-url.html src=src subpath=page.media_subpath absolute=true %}
       {%- endcapture -%}
 
-      {%- capture old_url -%}{{ src | absolute_url }}{%- endcapture -%}
+      {%- capture old_url -%}{{ src | prepend: page.url | absolute_url }}{%- endcapture -%}
       {%- capture new_url -%}{{ img_url }}{%- endcapture -%}
 
       {% assign seo_tags = seo_tags | replace: old_url, new_url %}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

When a post specifies an image using only a file name (for example, `image: cover.png`) together with `media_subpath`, the generated social share image URL is incorrect.

Instead of pointing to the actual image, it points to the post URL:

- **Generated:** `https://example.com/posts/my-post/cover.png` ❌ (404)
- **Expected:** `https://example.com/assets/img/.../cover.png`

Because the image URL is broken, social platforms such as Facebook, LinkedIn, WhatsApp, and X cannot display a preview image when the post is shared.

### Why it happens

In `_includes/head.html`, the theme corrects the image URL by performing a find-and-replace on the output generated by `jekyll-seo-tag`. This used to work, but `jekyll-seo-tag` changed how it resolves a bare file name in **version 2.9.0**, and the theme was not updated to match.

Since 2.9.0, when the `image` value is just a file name (no leading slash), `jekyll-seo-tag` builds the URL from the **post URL**:

```text
{site.url}{page.url}{image}
```

Before 2.9.0, it built the URL from the **site root**, so the theme's find-and-replace matched and everything worked.

The theme, however, still searches for a URL built from the site root:

```text
{site.url}/{image}
```

Since these two URLs no longer match, the replacement never happens and the broken image URL is left unchanged.

This can be seen directly in `jekyll-seo-tag` 2.9.0 (`lib/jekyll-seo-tag/image_drop.rb`, `build_absolute_path`): a path starting with `/` is resolved from the site root, but a bare file name is resolved with `File.join(page.url, image)`.

Chirpy's gem spec allows `jekyll-seo-tag ~> 2.8`, which permits 2.9.0, so any user on 2.9.0+ is affected.

### The fix

Build the search value the same way `jekyll-seo-tag` does—using the post URL:

```liquid
{%- capture old_url -%}{{ src | prepend: page.url | absolute_url }}{%- endcapture -%}
```

For posts and pages (whose permalinks end in `/`), `page.url` + `image` is exactly the string `jekyll-seo-tag` now produces, so the find-and-replace matches again.

### How to reproduce (before this fix)

Given the following post:

```yaml
---
title: Repro
media_subpath: /assets/img/posts/repro
image: cover.png
---
```

The generated metadata contains:

```html
<meta property="og:image" content="https://example.com/posts/repro/cover.png" />
```

This URL returns **404** instead of the actual image.

## Tested

Verified that the fix:

- ✅ Corrects the broken `media_subpath` + filename case.
- ✅ Continues to work with images that use an absolute site path (for example, `/assets/...`).
- ✅ Continues to work with images that use a full URL (for example, `https://...`).
- ✅ Does not affect pages without an `image`, which continue to fall back to `social_preview_image`.

### Environment

- Chirpy 7.6.0
- `jekyll-seo-tag` 2.9.0 (bug appears on 2.9.0+, not on 2.8.x)
- Jekyll 4.4.1
- Ruby 3.4