### PR TITLE
fix(layout): add whitespace between html tag attributes

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,9 @@ layout: compress
 <!-- `site.alt_lang` can specify a language different from the UI -->
 <html
   lang="{{ page.lang | default: site.alt_lang | default: site.lang }}"
-  {%- if site.theme_mode == 'light' or site.theme_mode == 'dark' %} data-bs-theme="{{ site.theme_mode }}"{% endif -%}
+  {%- if site.theme_mode == 'light' or site.theme_mode == 'dark' %}
+    data-bs-theme="{{ site.theme_mode }}"
+  {%- endif -%}
 >
   {% include head.html lang=lang %}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,9 +11,7 @@ layout: compress
 <!-- `site.alt_lang` can specify a language different from the UI -->
 <html
   lang="{{ page.lang | default: site.alt_lang | default: site.lang }}"
-  {%- if site.theme_mode == 'light' or site.theme_mode == 'dark' -%}
-    data-bs-theme="{{ site.theme_mode }}"
-  {%- endif -%}
+  {%- if site.theme_mode == 'light' or site.theme_mode == 'dark' %} data-bs-theme="{{ site.theme_mode }}"{% endif -%}
 >
   {% include head.html lang=lang %}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@ layout: compress
 <!-- `site.alt_lang` can specify a language different from the UI -->
 <html
   lang="{{ page.lang | default: site.alt_lang | default: site.lang }}"
-  {%- if site.theme_mode == 'light' or site.theme_mode == 'dark' %}
+  {% if site.theme_mode == 'light' or site.theme_mode == 'dark' -%}
     data-bs-theme="{{ site.theme_mode }}"
   {%- endif -%}
 >


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

The `<html>` element in `_layouts/default.html` renders its attributes without a separating space, producing invalid HTML:

```html
<html lang="en"data-bs-theme="light">
```

Running `htmlproofer --check-html` reports:

> Missing whitespace between attributes

(See #2765.)

### Root cause

The whitespace-trim markers introduced in `7496dd4` remove all whitespace around the `data-bs-theme` conditional, including the required separator between the `lang` and `data-bs-theme` attributes:

```liquid
{%- if site.theme_mode == 'light' or site.theme_mode == 'dark' -%}
  data-bs-theme="{{ site.theme_mode }}"
{%- endif -%}
```

### Fix

Trim only the newline before the conditional while emitting an explicit space before `data-bs-theme`:

```diff
- {%- if site.theme_mode == 'light' or site.theme_mode == 'dark' -%}
-   data-bs-theme="{{ site.theme_mode }}"
- {%- endif -%}
+ {%- if site.theme_mode == 'light' or site.theme_mode == 'dark' %} data-bs-theme="{{ site.theme_mode }}"{% endif -%}
```

The generated output is now valid:

```html
<html 
  lang="en" data-bs-theme="light">
```

When `theme_mode` is unset (the default/auto mode), the `data-bs-theme` attribute is still omitted:

```html
<html lang="en">
```

There is no behavioral change—this fix only restores the required whitespace between attributes when a theme mode is configured.

### Testing

Built the site with:

```sh
JEKYLL_ENV=production
```

Verified that the generated `<html>` tag contains valid whitespace between the `lang` and `data-bs-theme` attributes.

## Additional context

Fixes #2765.