### PR TITLE
fix(head): add missing comma between viewport meta properties

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
   <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1b1b1e">
   <meta
     name="viewport"
-    content="width=device-width, user-scalable=no initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+    content="width=device-width, user-scalable=no, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
   >
 
   {%- capture seo_tags -%}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

The `viewport` meta tag in `_includes/head.html` is missing a comma between the `user-scalable` and `initial-scale` properties:

```html
<meta
  name="viewport"
  content="width=device-width, user-scalable=no initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
>
```

Every other property in the list is comma-separated, but `user-scalable=no` and `initial-scale=1` are separated only by a space, making the value inconsistent with the rest of the list.

### Fix

Add the missing comma so all properties are consistently comma-separated:

```diff
- content="width=device-width, user-scalable=no initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+ content="width=device-width, user-scalable=no, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
```

There is no behavioral change. Browsers already parse both properties correctly because whitespace is accepted as a separator. This change simply improves the syntax for consistency and validity.

## Additional context

No existing issue — noticed while validating the generated HTML.