### PR TITLE
Bypass cache for third-party plugins

### DIFF
--- a/_javascript/pwa/sw.js
+++ b/_javascript/pwa/sw.js
@@ -1,28 +1,16 @@
 importScripts('./assets/js/data/swconf.js');
 
 const purge = swconf.purge;
-const interceptor = swconf.interceptor;
+const denyRegexes = swconf.denyUrls.map((regex) => new RegExp(regex));
 
 function verifyUrl(url) {
   const requestUrl = new URL(url);
-  const requestPath = requestUrl.pathname;
 
-  if (!requestUrl.protocol.startsWith('http')) {
+  if (requestUrl.protocol !== 'http:' && requestUrl.protocol !== 'https:') {
     return false;
   }
 
-  for (const prefix of interceptor.urlPrefixes) {
-    if (requestUrl.href.startsWith(prefix)) {
-      return false;
-    }
-  }
-
-  for (const path of interceptor.paths) {
-    if (requestPath.startsWith(path)) {
-      return false;
-    }
-  }
-  return true;
+  return !denyRegexes.some((regex) => regex.test(url));
 }
 
 self.addEventListener('install', (event) => {
@@ -32,7 +20,7 @@ self.addEventListener('install', (event) => {
 
   event.waitUntil(
     caches.open(swconf.cacheName).then((cache) => {
-      return cache.addAll(swconf.resources);
+      return cache.addAll(swconf.precacheUrls);
     })
   );
 });

--- a/assets/js/data/search.json
+++ b/assets/js/data/search.json
@@ -1,6 +1,5 @@
 ---
 layout: compress
-swcache: true
 ---
 
 [

--- a/assets/js/data/swconf.js
+++ b/assets/js/data/swconf.js
@@ -5,43 +5,81 @@ permalink: '/:path/swconf.js'
 ---
 
 const swconf = {
-  {% if site.pwa.cache.enabled %}
+  {%- if site.pwa.cache.enabled %}
     cacheName: 'chirpy-{{ "now" | date: "%s" }}',
 
-    {%- comment -%} Resources added to the cache during PWA installation. {%- endcomment -%}
-    resources: [
+    {%- comment -%} The specific list of URLs automatically cached during PWA installation. {% endcomment %}
+    precacheUrls: [
       '{{ "/assets/css/:THEME.css" | replace: ':THEME', site.theme | relative_url }}',
       '{{ "/" | relative_url }}',
-      {% for tab in site.tabs %}
-        '{{- tab.url | relative_url -}}',
+      {% for tab in site.tabs -%}
+        '{{ tab.url | relative_url }}',
       {% endfor %}
 
-      {% assign cache_list = site.static_files | where: 'swcache', true %}
-      {% for file in cache_list %}
-        '{{ file.path | relative_url }}'{%- unless forloop.last -%},{%- endunless -%}
-      {% endfor %}
+      {%- assign cache_list = site.static_files | where: 'precache', true -%}
+      {% for file in cache_list -%}
+        '{{- file.path | relative_url -}}'{%- unless forloop.last -%},{% endunless %}
+      {% endfor -%}
     ],
 
-    interceptor: {
-      {%- comment -%} URLs containing the following paths will not be cached. {%- endcomment -%}
-      paths: [
-        {% for path in site.pwa.cache.deny_paths %}
-          {% unless path == empty %}
-            '{{ path | relative_url }}'{%- unless forloop.last -%},{%- endunless -%}
-          {% endunless  %}
-        {% endfor %}
-      ],
+    {%- comment -%} Define URLs that should be excluded from the cache. {%- endcomment -%}
 
-      {%- comment -%} URLs containing the following prefixes will not be cached. {%- endcomment -%}
-      urlPrefixes: [
-        {% if site.analytics.goatcounter.id != nil and site.pageviews.provider == 'goatcounter' %}
-          'https://{{ site.analytics.goatcounter.id }}.goatcounter.com/counter/'
-        {% endif %}
-      ]
-    },
+    {%- assign deny_urls = '' -%}
 
+    {%- if site.comments.provider -%}
+      {%- case site.comments.provider -%}
+        {%- when 'disqus' -%}
+          {%- assign deny_urls = deny_urls | append: 'disqus\.com::' -%}
+        {%- when 'utterances' -%}
+          {%- assign deny_urls = deny_urls | append: 'utteranc\.es::' -%}
+        {%- when 'giscus' -%}
+          {%- assign deny_urls = deny_urls | append: 'giscus\.app::' -%}
+      {%- endcase -%}
+    {%- endif -%}
+
+    {%- comment -%} Analytics & Pageviews providers {% endcomment -%}
+
+    {%- if site.analytics.google.id -%}
+      {%- assign deny_urls = deny_urls | append: 'googletagmanager\.com::' -%}
+    {%- endif %}
+
+    {%- if site.analytics.goatcounter.id -%}
+      {%- assign deny_urls = deny_urls | append: '\.zgo\.at::' -%}
+    {%- endif %}
+
+    {%- if site.analytics.cloudflare.id -%}
+      {%- assign deny_urls = deny_urls | append: '\.cloudflareinsights\.com::' -%}
+    {%- endif %}
+
+    {%- if site.analytics.fathom.id -%}
+      {%- assign deny_urls = deny_urls | append: '\.usefathom\.com::' -%}
+    {%- endif -%}
+
+    {%- if site.analytics.umami.id and site.analytics.umami.domain -%}
+      {%- assign umami_domain = site.analytics.umami.domain | replace: '.', '\.' -%}
+      {%- assign deny_urls = deny_urls | append: umami_domain | append: '::' -%}
+    {%- endif -%}
+
+    {%- if site.analytics.matomo.id and site.analytics.matomo.domain -%}
+      {%- assign matomo_domain = site.analytics.matomo.domain | replace: '.', '\.' -%}
+      {%- assign deny_urls = deny_urls | append: matomo_domain | append: '::' -%}
+    {%- endif -%}
+
+    {%- if site.pageviews.provider -%}
+      {%- case site.pageviews.provider -%}
+        {%- when 'goatcounter' -%}
+          {%- assign deny_urls = deny_urls | append: '\.goatcounter\.com::' -%}
+      {%- endcase -%}
+    {%- endif -%}
+
+    {%- for path in site.pwa.cache.deny_paths -%}
+      {%- assign url = path | absolute_url | replace: '/', '\/' -%}
+      {%- assign deny_urls = deny_urls | append: url | append: '::' -%}
+    {%- endfor %}
+
+    denyUrls: {{ deny_urls | split: '::' | jsonify }},
     purge: false
-  {% else %}
+  {%- else %}
     purge: true
-  {% endif %}
+  {%- endif %}
 };


### PR DESCRIPTION
## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (refactoring and improving code)

## Description

If dynamic JS files from third-party platforms (comment or analytics platforms) are cached, plugin loading may fail in the future due to an inability to sync with remote updates.

Therefore, this change automatically generates resource filtering rules for the analytics and commenting systems based on the user's config settings, ensuring that the PWA does not cache these types of resources.

**Refactor**: This update uses regular expressions to improve URLs validation.

## Additional context

N/A
